### PR TITLE
[Work In Progress] Add search_covered method

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,11 @@ A simple example that demonstrates most of the features: ::
 	# that contains the search term (inverse routing-style lookup)
 	rnode = rtree.search_worst("10.123.45.6")
 
+	# Covered search will return all prefixes inside the given
+	# search term, as a list (including the search term itself,
+	# if present in the tree)
+	rnodes = rtree.search_covered("10.123.0.0/16")
+
 	# There are a couple of implicit members of a RadixNode:
 	print rnode.network	# -> "10.0.0.0"
 	print rnode.prefix	# -> "10.0.0.0/8"

--- a/radix/__init__.py
+++ b/radix/__init__.py
@@ -17,6 +17,7 @@ class Radix(object):
         self.search_exact = self._radix.search_exact
         self.search_best = self._radix.search_best
         self.search_worst = self._radix.search_worst
+        self.search_covered = self._radix.search_covered
         self.nodes = self._radix.nodes
         self.prefixes = self._radix.prefixes
 

--- a/radix/_radix.c
+++ b/radix/_radix.c
@@ -543,18 +543,18 @@ Radix_search_covered(RadixObject *self, PyObject *args, PyObject *kw_args)
         //         return Py_None;
         // }
 
-        // RADIX_WALK(self->rt4->head, node) {
-        //         if (node->data != NULL) {
-        //                 PyList_Append(ret,
-        //                     ((RadixNodeObject *)node->data)->prefix);
-        //         }
-        // } RADIX_WALK_END;
-        // RADIX_WALK(self->rt6->head, node) {
-        //         if (node->data != NULL) {
-        //                 PyList_Append(ret,
-        //                     ((RadixNodeObject *)node->data)->prefix);
-        //         }
-        // } RADIX_WALK_END;
+        RADIX_WALK(self->rt4->head, node) {
+                if (node->data != NULL) {
+                        PyList_Append(ret,
+                            ((RadixNodeObject *)node->data));
+                }
+        } RADIX_WALK_END;
+        RADIX_WALK(self->rt6->head, node) {
+                if (node->data != NULL) {
+                        PyList_Append(ret,
+                            ((RadixNodeObject *)node->data));
+                }
+        } RADIX_WALK_END;
 
         Deref_Prefix(prefix);
         return (ret);

--- a/radix/_radix.c
+++ b/radix/_radix.c
@@ -508,6 +508,58 @@ Radix_search_worst(RadixObject *self, PyObject *args, PyObject *kw_args)
         return (PyObject *)node_obj;
 }
 
+PyDoc_STRVAR(Radix_search_covered_doc,
+"Radix.search_covered(network[, masklen][, packed] -> None\n\
+\n\
+FIXME");
+
+static PyObject *
+Radix_search_covered(RadixObject *self, PyObject *args, PyObject *kw_args)
+{
+        radix_node_t *node;
+        RadixNodeObject *node_obj;
+        prefix_t *prefix;
+        PyObject *ret;
+
+        static char *keywords[] = { "network", "masklen", "packed", NULL };
+
+        char *addr = NULL, *packed = NULL;
+        long prefixlen = -1;
+        int packlen = -1;
+
+        if (!PyArg_ParseTupleAndKeywords(args, kw_args, "|sls#:search_covered", keywords,
+            &addr, &prefixlen, &packed, &packlen))
+                return NULL;
+        if ((prefix = args_to_prefix(addr, packed, packlen, prefixlen)) == NULL)
+                return NULL;
+
+        if ((ret = PyList_New(0)) == NULL)
+                return NULL;
+
+        // if ((node = radix_search_worst(PICKRT(prefix, self), prefix)) == NULL || 
+        //     node->data == NULL) {
+        //         Deref_Prefix(prefix);
+        //         Py_INCREF(Py_None);
+        //         return Py_None;
+        // }
+
+        // RADIX_WALK(self->rt4->head, node) {
+        //         if (node->data != NULL) {
+        //                 PyList_Append(ret,
+        //                     ((RadixNodeObject *)node->data)->prefix);
+        //         }
+        // } RADIX_WALK_END;
+        // RADIX_WALK(self->rt6->head, node) {
+        //         if (node->data != NULL) {
+        //                 PyList_Append(ret,
+        //                     ((RadixNodeObject *)node->data)->prefix);
+        //         }
+        // } RADIX_WALK_END;
+
+        Deref_Prefix(prefix);
+        return (ret);
+}
+
 
 PyDoc_STRVAR(Radix_nodes_doc,
 "Radix.nodes(prefix) -> List of RadixNode\n\
@@ -589,6 +641,7 @@ static PyMethodDef Radix_methods[] = {
         {"search_exact",(PyCFunction)Radix_search_exact,METH_VARARGS|METH_KEYWORDS,     Radix_search_exact_doc  },
         {"search_best", (PyCFunction)Radix_search_best, METH_VARARGS|METH_KEYWORDS,     Radix_search_best_doc   },
         {"search_worst", (PyCFunction)Radix_search_worst, METH_VARARGS|METH_KEYWORDS,     Radix_search_worst_doc   },
+        {"search_covered", (PyCFunction)Radix_search_covered, METH_VARARGS|METH_KEYWORDS,     Radix_search_covered_doc   },
         {"nodes",       (PyCFunction)Radix_nodes,       METH_VARARGS,                   Radix_nodes_doc         },
         {"prefixes",    (PyCFunction)Radix_prefixes,    METH_VARARGS,                   Radix_prefixes_doc      },
         {NULL,          NULL}           /* sentinel */

--- a/radix/radix.py
+++ b/radix/radix.py
@@ -324,6 +324,34 @@ class RadixTree(object):
                 return node
         return None
 
+    def search_covered(self, prefix):
+        results = []
+        if self.head is None:
+            return results
+        node = self.head
+        addr = prefix.addr
+        bitlen = prefix.bitlen
+
+        while node.bitlen < bitlen:
+            if self._addr_test(addr, node.bitlen):
+                node = node.right
+            else:
+                node = node.left
+            if node is None:
+                return results
+
+        stack = [node]
+        while stack:
+            node = stack.pop()
+            if self._prefix_match(node._prefix, prefix, prefix.bitlen):
+                results.append(node)
+            if node.right:
+                stack.append(node.right)
+            if node.left:
+                stack.append(node.left)
+
+        return results
+
     def _prefix_match(self, left, right, bitlen):
         l = left.addr
         r = right.addr
@@ -447,6 +475,13 @@ class Radix(object):
             return node
         else:
             return None
+
+    def search_covered(self, network=None, masklen=None, packed=None):
+        prefix = RadixPrefix(network, masklen, packed)
+        if prefix.family == AF_INET:
+            return self._tree4.search_covered(prefix)
+        else:
+            return self._tree6.search_covered(prefix)
 
     def _iter(self, node):
         stack = []

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -38,332 +38,332 @@ else:
 
 
 class TestRadix(unittest.TestCase):
-    def test_00__create_destroy(self):
-        tree = radix.Radix()
-        self.assertTrue('radix.Radix' in str(type(tree)))
-        del tree
+    # def test_00__create_destroy(self):
+    #     tree = radix.Radix()
+    #     self.assertTrue('radix.Radix' in str(type(tree)))
+    #     del tree
 
-    def test_01__create_node(self):
-        tree = radix.Radix()
-        node = tree.add("10.0.0.0/8")
-        self.assertTrue('radix.RadixNode' in str(type(node)))
-        self.assertEqual(node.prefix, "10.0.0.0/8")
-        self.assertEqual(node.network, "10.0.0.0")
-        self.assertEqual(node.prefixlen, 8)
-        self.assertEqual(node.family, socket.AF_INET)
-        node = tree.add("10.0.0.0", 16)
-        self.assertEqual(node.network, "10.0.0.0")
-        self.assertEqual(node.prefixlen, 16)
-        node = tree.add(network="10.0.0.0", masklen=24)
-        self.assertEqual(node.network, "10.0.0.0")
-        self.assertEqual(node.prefixlen, 24)
-        node2 = tree.add(network="ff00::", masklen=24)
-        self.assertEqual(node2.network, "ff00::")
-        self.assertEqual(node2.prefixlen, 24)
-        self.assertTrue(node is not node2)
+    # def test_01__create_node(self):
+    #     tree = radix.Radix()
+    #     node = tree.add("10.0.0.0/8")
+    #     self.assertTrue('radix.RadixNode' in str(type(node)))
+    #     self.assertEqual(node.prefix, "10.0.0.0/8")
+    #     self.assertEqual(node.network, "10.0.0.0")
+    #     self.assertEqual(node.prefixlen, 8)
+    #     self.assertEqual(node.family, socket.AF_INET)
+    #     node = tree.add("10.0.0.0", 16)
+    #     self.assertEqual(node.network, "10.0.0.0")
+    #     self.assertEqual(node.prefixlen, 16)
+    #     node = tree.add(network="10.0.0.0", masklen=24)
+    #     self.assertEqual(node.network, "10.0.0.0")
+    #     self.assertEqual(node.prefixlen, 24)
+    #     node2 = tree.add(network="ff00::", masklen=24)
+    #     self.assertEqual(node2.network, "ff00::")
+    #     self.assertEqual(node2.prefixlen, 24)
+    #     self.assertTrue(node is not node2)
 
-    def test_02__node_userdata(self):
-        tree = radix.Radix()
-        node = tree.add(network="10.0.0.0", masklen=28)
-        node.data["blah"] = "abc123"
-        node.data["foo"] = 12345
-        self.assertEqual(node.data["blah"], "abc123")
-        self.assertEqual(node.data["foo"], 12345)
-        self.assertRaises(AttributeError, lambda x: x.nonexist, node)
-        del node.data["blah"]
-        self.assertRaises(KeyError, lambda x: x.data["blah"], node)
+    # def test_02__node_userdata(self):
+    #     tree = radix.Radix()
+    #     node = tree.add(network="10.0.0.0", masklen=28)
+    #     node.data["blah"] = "abc123"
+    #     node.data["foo"] = 12345
+    #     self.assertEqual(node.data["blah"], "abc123")
+    #     self.assertEqual(node.data["foo"], 12345)
+    #     self.assertRaises(AttributeError, lambda x: x.nonexist, node)
+    #     del node.data["blah"]
+    #     self.assertRaises(KeyError, lambda x: x.data["blah"], node)
 
-    def test_03__search_exact(self):
-        tree = radix.Radix()
-        node1 = tree.add("10.0.0.0/8")
-        node2 = tree.add("10.0.0.0/16")
-        node3 = tree.add("10.0.0.0/24")
-        node2.data["foo"] = 12345
-        node = tree.search_exact("127.0.0.1")
-        self.assertEqual(node, None)
-        node = tree.search_exact("10.0.0.0")
-        self.assertEqual(node, None)
-        node = tree.search_exact("10.0.0.0/24")
-        self.assertEqual(node, node3)
-        node = tree.search_exact("10.0.0.0/8")
-        self.assertEqual(node, node1)
-        node = tree.search_exact("10.0.0.0/16")
-        self.assertEqual(node.data["foo"], 12345)
+    # def test_03__search_exact(self):
+    #     tree = radix.Radix()
+    #     node1 = tree.add("10.0.0.0/8")
+    #     node2 = tree.add("10.0.0.0/16")
+    #     node3 = tree.add("10.0.0.0/24")
+    #     node2.data["foo"] = 12345
+    #     node = tree.search_exact("127.0.0.1")
+    #     self.assertEqual(node, None)
+    #     node = tree.search_exact("10.0.0.0")
+    #     self.assertEqual(node, None)
+    #     node = tree.search_exact("10.0.0.0/24")
+    #     self.assertEqual(node, node3)
+    #     node = tree.search_exact("10.0.0.0/8")
+    #     self.assertEqual(node, node1)
+    #     node = tree.search_exact("10.0.0.0/16")
+    #     self.assertEqual(node.data["foo"], 12345)
 
-    def test_04__search_best(self):
-        tree = radix.Radix()
-        node2 = tree.add("10.0.0.0/16")
-        node3 = tree.add("10.0.0.0/24")
-        node = tree.search_best("127.0.0.1")
-        self.assertEqual(node, None)
-        node = tree.search_best("10.0.0.0")
-        self.assertEqual(node, node3)
-        node = tree.search_best("10.0.0.0/24")
-        self.assertEqual(node, node3)
-        node = tree.search_best("10.0.1.0/24")
-        self.assertEqual(node, node2)
+    # def test_04__search_best(self):
+    #     tree = radix.Radix()
+    #     node2 = tree.add("10.0.0.0/16")
+    #     node3 = tree.add("10.0.0.0/24")
+    #     node = tree.search_best("127.0.0.1")
+    #     self.assertEqual(node, None)
+    #     node = tree.search_best("10.0.0.0")
+    #     self.assertEqual(node, node3)
+    #     node = tree.search_best("10.0.0.0/24")
+    #     self.assertEqual(node, node3)
+    #     node = tree.search_best("10.0.1.0/24")
+    #     self.assertEqual(node, node2)
 
-    def test_05__concurrent_trees(self):
-        tree1 = radix.Radix()
-        node1_2 = tree1.add("10.0.0.0/16")
-        node1_3 = tree1.add("10.0.0.0/24")
-        node1_3.data["blah"] = 12345
-        tree2 = radix.Radix()
-        node2_2 = tree2.add("10.0.0.0/16")
-        node2_3 = tree2.add("10.0.0.0/24")
-        node2_3.data["blah"] = 45678
-        self.assertNotEqual(tree1, tree2)
-        self.assertNotEqual(node1_2, node2_2)
-        node = tree1.search_best("10.0.1.0/24")
-        self.assertEqual(node, node1_2)
-        self.assertNotEqual(node, node2_2)
-        node = tree2.search_best("20.0.0.0/24")
-        self.assertEqual(node, None)
-        node = tree2.search_best("10.0.0.10")
-        self.assertEqual(node.data["blah"], 45678)
+    # def test_05__concurrent_trees(self):
+    #     tree1 = radix.Radix()
+    #     node1_2 = tree1.add("10.0.0.0/16")
+    #     node1_3 = tree1.add("10.0.0.0/24")
+    #     node1_3.data["blah"] = 12345
+    #     tree2 = radix.Radix()
+    #     node2_2 = tree2.add("10.0.0.0/16")
+    #     node2_3 = tree2.add("10.0.0.0/24")
+    #     node2_3.data["blah"] = 45678
+    #     self.assertNotEqual(tree1, tree2)
+    #     self.assertNotEqual(node1_2, node2_2)
+    #     node = tree1.search_best("10.0.1.0/24")
+    #     self.assertEqual(node, node1_2)
+    #     self.assertNotEqual(node, node2_2)
+    #     node = tree2.search_best("20.0.0.0/24")
+    #     self.assertEqual(node, None)
+    #     node = tree2.search_best("10.0.0.10")
+    #     self.assertEqual(node.data["blah"], 45678)
 
-    def test_06__deletes(self):
-        tree = radix.Radix()
-        node1 = tree.add("10.0.0.0/8")
-        self.assertRaises(KeyError, tree.delete, "127.0.0.1")
-        self.assertRaises(KeyError, tree.delete, "10.0.0.0/24")
-        node = tree.search_best("10.0.0.10")
-        self.assertEqual(node, node1)
+    # def test_06__deletes(self):
+    #     tree = radix.Radix()
+    #     node1 = tree.add("10.0.0.0/8")
+    #     self.assertRaises(KeyError, tree.delete, "127.0.0.1")
+    #     self.assertRaises(KeyError, tree.delete, "10.0.0.0/24")
+    #     node = tree.search_best("10.0.0.10")
+    #     self.assertEqual(node, node1)
 
-    def test_07__nodes(self):
-        tree = radix.Radix()
-        prefixes = [
-            "10.0.0.0/8", "127.0.0.1/32",
-            "10.1.0.0/16", "10.100.100.100/32",
-            "abcd:ef12::/32", "abcd:ef01:2345:6789::/64", "::1/128"
-        ]
-        prefixes.sort()
-        for prefix in prefixes:
-            tree.add(prefix)
-        nodes = tree.nodes()
-        addrs = list(map(lambda x: x.prefix, nodes))
-        addrs.sort()
-        self.assertEqual(addrs, prefixes)
+    # def test_07__nodes(self):
+    #     tree = radix.Radix()
+    #     prefixes = [
+    #         "10.0.0.0/8", "127.0.0.1/32",
+    #         "10.1.0.0/16", "10.100.100.100/32",
+    #         "abcd:ef12::/32", "abcd:ef01:2345:6789::/64", "::1/128"
+    #     ]
+    #     prefixes.sort()
+    #     for prefix in prefixes:
+    #         tree.add(prefix)
+    #     nodes = tree.nodes()
+    #     addrs = list(map(lambda x: x.prefix, nodes))
+    #     addrs.sort()
+    #     self.assertEqual(addrs, prefixes)
 
-    def test_08__nodes_empty_tree(self):
-        tree = radix.Radix()
-        nodes = tree.nodes()
-        self.assertEqual(nodes, [])
+    # def test_08__nodes_empty_tree(self):
+    #     tree = radix.Radix()
+    #     nodes = tree.nodes()
+    #     self.assertEqual(nodes, [])
 
-    def test_09__prefixes(self):
-        tree = radix.Radix()
-        prefixes = [
-            "10.0.0.0/8", "127.0.0.1/32",
-            "10.1.0.0/16", "10.100.100.100/32",
-            "abcd:ef12::/32", "abcd:ef01:2345:6789::/64", "::1/128"
-        ]
-        prefixes.sort()
-        for prefix in prefixes:
-            tree.add(prefix)
-        addrs = tree.prefixes()
-        addrs.sort()
-        self.assertEqual(addrs, prefixes)
+    # def test_09__prefixes(self):
+    #     tree = radix.Radix()
+    #     prefixes = [
+    #         "10.0.0.0/8", "127.0.0.1/32",
+    #         "10.1.0.0/16", "10.100.100.100/32",
+    #         "abcd:ef12::/32", "abcd:ef01:2345:6789::/64", "::1/128"
+    #     ]
+    #     prefixes.sort()
+    #     for prefix in prefixes:
+    #         tree.add(prefix)
+    #     addrs = tree.prefixes()
+    #     addrs.sort()
+    #     self.assertEqual(addrs, prefixes)
 
-    def test_10__use_after_free(self):
-        tree = radix.Radix()
-        node1 = tree.add("10.0.0.0/8")
-        del tree
-        self.assertEquals(node1.prefix, "10.0.0.0/8")
+    # def test_10__use_after_free(self):
+    #     tree = radix.Radix()
+    #     node1 = tree.add("10.0.0.0/8")
+    #     del tree
+    #     self.assertEquals(node1.prefix, "10.0.0.0/8")
 
-    def test_11__unique_instance(self):
-        tree = radix.Radix()
-        node1 = tree.add("10.0.0.0/8")
-        node2 = tree.add("10.0.0.0/8")
-        self.assertTrue(node1 is node2)
-        self.assertTrue(node1.prefix is node2.prefix)
+    # def test_11__unique_instance(self):
+    #     tree = radix.Radix()
+    #     node1 = tree.add("10.0.0.0/8")
+    #     node2 = tree.add("10.0.0.0/8")
+    #     self.assertTrue(node1 is node2)
+    #     self.assertTrue(node1.prefix is node2.prefix)
 
-    def test_12__inconsistent_masks4(self):
-        tree = radix.Radix()
-        node1 = tree.add("10.255.255.255", 28)
-        node2 = tree.add(network="10.255.255.240/28")
-        node3 = tree.add(network="10.255.255.252", masklen=28)
-        self.assertTrue(node1 is node2)
-        self.assertTrue(node1 is node3)
-        self.assertEquals(node1.prefix, "10.255.255.240/28")
+    # def test_12__inconsistent_masks4(self):
+    #     tree = radix.Radix()
+    #     node1 = tree.add("10.255.255.255", 28)
+    #     node2 = tree.add(network="10.255.255.240/28")
+    #     node3 = tree.add(network="10.255.255.252", masklen=28)
+    #     self.assertTrue(node1 is node2)
+    #     self.assertTrue(node1 is node3)
+    #     self.assertEquals(node1.prefix, "10.255.255.240/28")
 
-    def test_13__inconsistent_masks6(self):
-        tree = radix.Radix()
-        node1 = tree.add("dead:beef:1234:5678::", 32)
-        node2 = tree.add(network="dead:beef:8888:9999::/32")
-        node3 = tree.add(network="dead:beef::", masklen=32)
-        self.assertTrue(node1 is node2)
-        self.assertTrue(node1 is node3)
-        self.assertEquals(node1.prefix, "dead:beef::/32")
+    # def test_13__inconsistent_masks6(self):
+    #     tree = radix.Radix()
+    #     node1 = tree.add("dead:beef:1234:5678::", 32)
+    #     node2 = tree.add(network="dead:beef:8888:9999::/32")
+    #     node3 = tree.add(network="dead:beef::", masklen=32)
+    #     self.assertTrue(node1 is node2)
+    #     self.assertTrue(node1 is node3)
+    #     self.assertEquals(node1.prefix, "dead:beef::/32")
 
-    def test_14__packed_addresses4(self):
-        tree = radix.Radix()
-        p = struct.pack('4B', 0xe0, 0x14, 0x0b, 0x40)
-        node = tree.add(packed=p, masklen=26)
-        self.assertEquals(node.family, socket.AF_INET)
-        self.assertEquals(node.prefix, "224.20.11.64/26")
-        self.assertEquals(node.packed, p)
+    # def test_14__packed_addresses4(self):
+    #     tree = radix.Radix()
+    #     p = struct.pack('4B', 0xe0, 0x14, 0x0b, 0x40)
+    #     node = tree.add(packed=p, masklen=26)
+    #     self.assertEquals(node.family, socket.AF_INET)
+    #     self.assertEquals(node.prefix, "224.20.11.64/26")
+    #     self.assertEquals(node.packed, p)
 
-    def test_15__packed_addresses6(self):
-        tree = radix.Radix()
-        p = struct.pack(
-            '16B',
-            0xde, 0xad, 0xbe, 0xef, 0x12, 0x34, 0x56, 0x78,
-            0x9a, 0xbc, 0xde, 0xf0, 0x00, 0x00, 0x00, 0x00)
-        node = tree.add(packed=p, masklen=108)
-        self.assertEquals(node.family, socket.AF_INET6)
-        self.assertEquals(
-            node.prefix,
-            "dead:beef:1234:5678:9abc:def0::/108")
-        self.assertEquals(node.packed, p)
+    # def test_15__packed_addresses6(self):
+    #     tree = radix.Radix()
+    #     p = struct.pack(
+    #         '16B',
+    #         0xde, 0xad, 0xbe, 0xef, 0x12, 0x34, 0x56, 0x78,
+    #         0x9a, 0xbc, 0xde, 0xf0, 0x00, 0x00, 0x00, 0x00)
+    #     node = tree.add(packed=p, masklen=108)
+    #     self.assertEquals(node.family, socket.AF_INET6)
+    #     self.assertEquals(
+    #         node.prefix,
+    #         "dead:beef:1234:5678:9abc:def0::/108")
+    #     self.assertEquals(node.packed, p)
 
-    def test_16__bad_addresses(self):
-        tree = radix.Radix()
-        self.assertRaises(TypeError, tree.add)
-        self.assertRaises(ValueError, tree.add, "blah/32")
-        self.assertRaises(ValueError, tree.add, "blah", 32)
-        self.assertRaises(ValueError, tree.add, "127.0.0.1", -2)
-        self.assertRaises(ValueError, tree.add, "127.0.0.1", 64)
-        self.assertRaises(ValueError, tree.add, "::", -2)
-        self.assertRaises(ValueError, tree.add, "::", 256)
-        self.assertEquals(len(tree.nodes()), 0)
+    # def test_16__bad_addresses(self):
+    #     tree = radix.Radix()
+    #     self.assertRaises(TypeError, tree.add)
+    #     self.assertRaises(ValueError, tree.add, "blah/32")
+    #     self.assertRaises(ValueError, tree.add, "blah", 32)
+    #     self.assertRaises(ValueError, tree.add, "127.0.0.1", -2)
+    #     self.assertRaises(ValueError, tree.add, "127.0.0.1", 64)
+    #     self.assertRaises(ValueError, tree.add, "::", -2)
+    #     self.assertRaises(ValueError, tree.add, "::", 256)
+    #     self.assertEquals(len(tree.nodes()), 0)
 
-    def test_17__mixed_address_family(self):
-        tree = radix.Radix()
-        node1 = tree.add("255.255.255.255", 32)
-        node2 = tree.add("ffff::/32")
-        node1_o = tree.search_best("255.255.255.255")
-        node2_o = tree.search_best("ffff::")
-        self.assertTrue(node1 is node1_o)
-        self.assertTrue(node2 is node2_o)
-        self.assertNotEquals(node1.prefix, node2.prefix)
-        self.assertNotEquals(node1.network, node2.network)
-        self.assertNotEquals(node1.family, node2.family)
+    # def test_17__mixed_address_family(self):
+    #     tree = radix.Radix()
+    #     node1 = tree.add("255.255.255.255", 32)
+    #     node2 = tree.add("ffff::/32")
+    #     node1_o = tree.search_best("255.255.255.255")
+    #     node2_o = tree.search_best("ffff::")
+    #     self.assertTrue(node1 is node1_o)
+    #     self.assertTrue(node2 is node2_o)
+    #     self.assertNotEquals(node1.prefix, node2.prefix)
+    #     self.assertNotEquals(node1.network, node2.network)
+    #     self.assertNotEquals(node1.family, node2.family)
 
-    def test_18__iterator(self):
-        tree = radix.Radix()
-        prefixes = [
-            "::1/128", "2000::/16", "2000::/8", "dead:beef::/64",
-            "ffff::/16", "10.0.0.0/8", "a00::/8", "255.255.0.0/16",
-            "::/0", "0.0.0.0/0"
-        ]
-        prefixes.sort()
-        for prefix in prefixes:
-            tree.add(prefix)
-        iterprefixes = []
-        for node in tree:
-            iterprefixes.append(node.prefix)
-        iterprefixes.sort()
-        self.assertEqual(iterprefixes, prefixes)
+    # def test_18__iterator(self):
+    #     tree = radix.Radix()
+    #     prefixes = [
+    #         "::1/128", "2000::/16", "2000::/8", "dead:beef::/64",
+    #         "ffff::/16", "10.0.0.0/8", "a00::/8", "255.255.0.0/16",
+    #         "::/0", "0.0.0.0/0"
+    #     ]
+    #     prefixes.sort()
+    #     for prefix in prefixes:
+    #         tree.add(prefix)
+    #     iterprefixes = []
+    #     for node in tree:
+    #         iterprefixes.append(node.prefix)
+    #     iterprefixes.sort()
+    #     self.assertEqual(iterprefixes, prefixes)
 
-    def test_19__iterate_on_empty(self):
-        tree = radix.Radix()
-        prefixes = []
-        for node in tree:
-            prefixes.append(node.prefix)
-        self.assertEqual(prefixes, [])
+    # def test_19__iterate_on_empty(self):
+    #     tree = radix.Radix()
+    #     prefixes = []
+    #     for node in tree:
+    #         prefixes.append(node.prefix)
+    #     self.assertEqual(prefixes, [])
 
-    def test_20__iterate_and_modify_tree(self):
-        tree = radix.Radix()
-        prefixes = [
-            "::1/128", "2000::/16", "2000::/8", "dead:beef::/64",
-            "0.0.0.0/8", "127.0.0.1/32"
-        ]
-        prefixes.sort()
-        for prefix in prefixes:
-            tree.add(prefix)
+    # def test_20__iterate_and_modify_tree(self):
+    #     tree = radix.Radix()
+    #     prefixes = [
+    #         "::1/128", "2000::/16", "2000::/8", "dead:beef::/64",
+    #         "0.0.0.0/8", "127.0.0.1/32"
+    #     ]
+    #     prefixes.sort()
+    #     for prefix in prefixes:
+    #         tree.add(prefix)
 
-        def iter_mod(t):
-            [t.delete(x.prefix) for x in t]
-        self.assertRaises(RuntimeWarning, iter_mod, tree)
+    #     def iter_mod(t):
+    #         [t.delete(x.prefix) for x in t]
+    #     self.assertRaises(RuntimeWarning, iter_mod, tree)
 
-    def test_21__lots_of_prefixes(self):
-        tree = radix.Radix()
-        num_nodes_in = 0
-        for i in range(0, 128):
-            for j in range(0, 128):
-                k = ((i + j) % 8) + 24
-                node = tree.add("1.%d.%d.0" % (i, j), k)
-                node.data["i"] = i
-                node.data["j"] = j
-                num_nodes_in += 1
+    # def test_21__lots_of_prefixes(self):
+    #     tree = radix.Radix()
+    #     num_nodes_in = 0
+    #     for i in range(0, 128):
+    #         for j in range(0, 128):
+    #             k = ((i + j) % 8) + 24
+    #             node = tree.add("1.%d.%d.0" % (i, j), k)
+    #             node.data["i"] = i
+    #             node.data["j"] = j
+    #             num_nodes_in += 1
 
-        num_nodes_del = 0
-        for i in range(0, 128, 5):
-            for j in range(0, 128, 3):
-                k = ((i + j) % 8) + 24
-                tree.delete("1.%d.%d.0" % (i, j), k)
-                num_nodes_del += 1
+    #     num_nodes_del = 0
+    #     for i in range(0, 128, 5):
+    #         for j in range(0, 128, 3):
+    #             k = ((i + j) % 8) + 24
+    #             tree.delete("1.%d.%d.0" % (i, j), k)
+    #             num_nodes_del += 1
 
-        num_nodes_out = 0
-        for node in tree:
-            i = node.data["i"]
-            j = node.data["j"]
-            k = ((i + j) % 8) + 24
-            prefix = "1.%d.%d.0/%d" % (i, j, k)
-            self.assertEquals(node.prefix, prefix)
-            num_nodes_out += 1
+    #     num_nodes_out = 0
+    #     for node in tree:
+    #         i = node.data["i"]
+    #         j = node.data["j"]
+    #         k = ((i + j) % 8) + 24
+    #         prefix = "1.%d.%d.0/%d" % (i, j, k)
+    #         self.assertEquals(node.prefix, prefix)
+    #         num_nodes_out += 1
 
-        self.assertEquals(num_nodes_in - num_nodes_del, num_nodes_out)
-        self.assertEquals(
-            num_nodes_in - num_nodes_del,
-            len(tree.nodes()))
+    #     self.assertEquals(num_nodes_in - num_nodes_del, num_nodes_out)
+    #     self.assertEquals(
+    #         num_nodes_in - num_nodes_del,
+    #         len(tree.nodes()))
 
-    def test_22__broken_sanitise(self):
-        tree = radix.Radix()
-        node = tree.add("255.255.255.255/15")
-        self.assertEquals(node.prefix, "255.254.0.0/15")
+    # def test_22__broken_sanitise(self):
+    #     tree = radix.Radix()
+    #     node = tree.add("255.255.255.255/15")
+    #     self.assertEquals(node.prefix, "255.254.0.0/15")
 
-    def test_21__pickle(self):
-        tree = radix.Radix()
-        num_nodes_in = 0
-        for i in range(0, 128):
-            for j in range(0, 128):
-                k = ((i + j) % 8) + 24
-                addr = "1.%d.%d.0" % (i, j)
-                node = tree.add(addr, k)
-                node.data["i"] = i
-                node.data["j"] = j
-                num_nodes_in += 1
-        tree_pickled = pickle.dumps(tree)
-        del tree
-        tree2 = pickle.loads(tree_pickled)
-        for i in range(0, 128):
-            for j in range(0, 128):
-                k = ((i + j) % 8) + 24
-                addr = "1.%d.%d.0" % (i, j)
-                node = tree2.search_exact(addr, k)
-                self.assertNotEquals(node, None)
-                self.assertEquals(node.data["i"], i)
-                self.assertEquals(node.data["j"], j)
-                node.data["j"] = j
-        self.assertEquals(len(tree2.nodes()), num_nodes_in)
+    # def test_21__pickle(self):
+    #     tree = radix.Radix()
+    #     num_nodes_in = 0
+    #     for i in range(0, 128):
+    #         for j in range(0, 128):
+    #             k = ((i + j) % 8) + 24
+    #             addr = "1.%d.%d.0" % (i, j)
+    #             node = tree.add(addr, k)
+    #             node.data["i"] = i
+    #             node.data["j"] = j
+    #             num_nodes_in += 1
+    #     tree_pickled = pickle.dumps(tree)
+    #     del tree
+    #     tree2 = pickle.loads(tree_pickled)
+    #     for i in range(0, 128):
+    #         for j in range(0, 128):
+    #             k = ((i + j) % 8) + 24
+    #             addr = "1.%d.%d.0" % (i, j)
+    #             node = tree2.search_exact(addr, k)
+    #             self.assertNotEquals(node, None)
+    #             self.assertEquals(node.data["i"], i)
+    #             self.assertEquals(node.data["j"], j)
+    #             node.data["j"] = j
+    #     self.assertEquals(len(tree2.nodes()), num_nodes_in)
 
-    def test_21__cpickle(self):
-        if sys.version_info[0] >= 3:
-            return
-        tree = radix.Radix()
-        num_nodes_in = 0
-        for i in range(0, 128):
-            for j in range(0, 128):
-                k = ((i + j) % 8) + 24
-                addr = "1.%d.%d.0" % (i, j)
-                node = tree.add(addr, k)
-                node.data["i"] = i
-                node.data["j"] = j
-                num_nodes_in += 1
-        tree_pickled = cPickle.dumps(tree)
-        del tree
-        tree2 = cPickle.loads(tree_pickled)
-        for i in range(0, 128):
-            for j in range(0, 128):
-                k = ((i + j) % 8) + 24
-                addr = "1.%d.%d.0" % (i, j)
-                node = tree2.search_exact(addr, k)
-                self.assertNotEquals(node, None)
-                self.assertEquals(node.data["i"], i)
-                self.assertEquals(node.data["j"], j)
-                node.data["j"] = j
-        self.assertEquals(len(tree2.nodes()), num_nodes_in)
+    # def test_21__cpickle(self):
+    #     if sys.version_info[0] >= 3:
+    #         return
+    #     tree = radix.Radix()
+    #     num_nodes_in = 0
+    #     for i in range(0, 128):
+    #         for j in range(0, 128):
+    #             k = ((i + j) % 8) + 24
+    #             addr = "1.%d.%d.0" % (i, j)
+    #             node = tree.add(addr, k)
+    #             node.data["i"] = i
+    #             node.data["j"] = j
+    #             num_nodes_in += 1
+    #     tree_pickled = cPickle.dumps(tree)
+    #     del tree
+    #     tree2 = cPickle.loads(tree_pickled)
+    #     for i in range(0, 128):
+    #         for j in range(0, 128):
+    #             k = ((i + j) % 8) + 24
+    #             addr = "1.%d.%d.0" % (i, j)
+    #             node = tree2.search_exact(addr, k)
+    #             self.assertNotEquals(node, None)
+    #             self.assertEquals(node.data["i"], i)
+    #             self.assertEquals(node.data["j"], j)
+    #             node.data["j"] = j
+    #     self.assertEquals(len(tree2.nodes()), num_nodes_in)
 
     def test_22_search_best(self):
         tree = radix.Radix()
@@ -395,6 +395,24 @@ class TestRadix(unittest.TestCase):
             tree.search_worst('100.0.0.0/15'),
             None)
 
+    def test_25_search_covered(self):
+        tree = radix.Radix()
+        tree.add('10.0.0.0/8')
+        tree.add('10.0.0.0/13')
+        tree.add('10.0.0.0/31')
+        tree.add('11.0.0.0/16')
+        self.assertEquals(
+            [n.prefix for n in tree.search_covered('10.0.0.0/8')],
+            ['10.0.0.0/8', '10.0.0.0/13', '10.0.0.0/31'])
+        self.assertEquals(
+            [n.prefix for n in tree.search_covered('11.0.0.0/8')],
+            ['11.0.0.0/16'])
+        self.assertEquals(
+            [n.prefix for n in tree.search_covered('21.0.0.0/8')],
+            [])
+        self.assertEquals(
+            [n.prefix for n in tree.search_covered('0.0.0.0/0')],
+            ['10.0.0.0/8', '10.0.0.0/13', '10.0.0.0/31', '11.0.0.0/16'])
 
 def main():
     unittest.main()

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -38,332 +38,332 @@ else:
 
 
 class TestRadix(unittest.TestCase):
-    # def test_00__create_destroy(self):
-    #     tree = radix.Radix()
-    #     self.assertTrue('radix.Radix' in str(type(tree)))
-    #     del tree
+    def test_00__create_destroy(self):
+        tree = radix.Radix()
+        self.assertTrue('radix.Radix' in str(type(tree)))
+        del tree
 
-    # def test_01__create_node(self):
-    #     tree = radix.Radix()
-    #     node = tree.add("10.0.0.0/8")
-    #     self.assertTrue('radix.RadixNode' in str(type(node)))
-    #     self.assertEqual(node.prefix, "10.0.0.0/8")
-    #     self.assertEqual(node.network, "10.0.0.0")
-    #     self.assertEqual(node.prefixlen, 8)
-    #     self.assertEqual(node.family, socket.AF_INET)
-    #     node = tree.add("10.0.0.0", 16)
-    #     self.assertEqual(node.network, "10.0.0.0")
-    #     self.assertEqual(node.prefixlen, 16)
-    #     node = tree.add(network="10.0.0.0", masklen=24)
-    #     self.assertEqual(node.network, "10.0.0.0")
-    #     self.assertEqual(node.prefixlen, 24)
-    #     node2 = tree.add(network="ff00::", masklen=24)
-    #     self.assertEqual(node2.network, "ff00::")
-    #     self.assertEqual(node2.prefixlen, 24)
-    #     self.assertTrue(node is not node2)
+    def test_01__create_node(self):
+        tree = radix.Radix()
+        node = tree.add("10.0.0.0/8")
+        self.assertTrue('radix.RadixNode' in str(type(node)))
+        self.assertEqual(node.prefix, "10.0.0.0/8")
+        self.assertEqual(node.network, "10.0.0.0")
+        self.assertEqual(node.prefixlen, 8)
+        self.assertEqual(node.family, socket.AF_INET)
+        node = tree.add("10.0.0.0", 16)
+        self.assertEqual(node.network, "10.0.0.0")
+        self.assertEqual(node.prefixlen, 16)
+        node = tree.add(network="10.0.0.0", masklen=24)
+        self.assertEqual(node.network, "10.0.0.0")
+        self.assertEqual(node.prefixlen, 24)
+        node2 = tree.add(network="ff00::", masklen=24)
+        self.assertEqual(node2.network, "ff00::")
+        self.assertEqual(node2.prefixlen, 24)
+        self.assertTrue(node is not node2)
 
-    # def test_02__node_userdata(self):
-    #     tree = radix.Radix()
-    #     node = tree.add(network="10.0.0.0", masklen=28)
-    #     node.data["blah"] = "abc123"
-    #     node.data["foo"] = 12345
-    #     self.assertEqual(node.data["blah"], "abc123")
-    #     self.assertEqual(node.data["foo"], 12345)
-    #     self.assertRaises(AttributeError, lambda x: x.nonexist, node)
-    #     del node.data["blah"]
-    #     self.assertRaises(KeyError, lambda x: x.data["blah"], node)
+    def test_02__node_userdata(self):
+        tree = radix.Radix()
+        node = tree.add(network="10.0.0.0", masklen=28)
+        node.data["blah"] = "abc123"
+        node.data["foo"] = 12345
+        self.assertEqual(node.data["blah"], "abc123")
+        self.assertEqual(node.data["foo"], 12345)
+        self.assertRaises(AttributeError, lambda x: x.nonexist, node)
+        del node.data["blah"]
+        self.assertRaises(KeyError, lambda x: x.data["blah"], node)
 
-    # def test_03__search_exact(self):
-    #     tree = radix.Radix()
-    #     node1 = tree.add("10.0.0.0/8")
-    #     node2 = tree.add("10.0.0.0/16")
-    #     node3 = tree.add("10.0.0.0/24")
-    #     node2.data["foo"] = 12345
-    #     node = tree.search_exact("127.0.0.1")
-    #     self.assertEqual(node, None)
-    #     node = tree.search_exact("10.0.0.0")
-    #     self.assertEqual(node, None)
-    #     node = tree.search_exact("10.0.0.0/24")
-    #     self.assertEqual(node, node3)
-    #     node = tree.search_exact("10.0.0.0/8")
-    #     self.assertEqual(node, node1)
-    #     node = tree.search_exact("10.0.0.0/16")
-    #     self.assertEqual(node.data["foo"], 12345)
+    def test_03__search_exact(self):
+        tree = radix.Radix()
+        node1 = tree.add("10.0.0.0/8")
+        node2 = tree.add("10.0.0.0/16")
+        node3 = tree.add("10.0.0.0/24")
+        node2.data["foo"] = 12345
+        node = tree.search_exact("127.0.0.1")
+        self.assertEqual(node, None)
+        node = tree.search_exact("10.0.0.0")
+        self.assertEqual(node, None)
+        node = tree.search_exact("10.0.0.0/24")
+        self.assertEqual(node, node3)
+        node = tree.search_exact("10.0.0.0/8")
+        self.assertEqual(node, node1)
+        node = tree.search_exact("10.0.0.0/16")
+        self.assertEqual(node.data["foo"], 12345)
 
-    # def test_04__search_best(self):
-    #     tree = radix.Radix()
-    #     node2 = tree.add("10.0.0.0/16")
-    #     node3 = tree.add("10.0.0.0/24")
-    #     node = tree.search_best("127.0.0.1")
-    #     self.assertEqual(node, None)
-    #     node = tree.search_best("10.0.0.0")
-    #     self.assertEqual(node, node3)
-    #     node = tree.search_best("10.0.0.0/24")
-    #     self.assertEqual(node, node3)
-    #     node = tree.search_best("10.0.1.0/24")
-    #     self.assertEqual(node, node2)
+    def test_04__search_best(self):
+        tree = radix.Radix()
+        node2 = tree.add("10.0.0.0/16")
+        node3 = tree.add("10.0.0.0/24")
+        node = tree.search_best("127.0.0.1")
+        self.assertEqual(node, None)
+        node = tree.search_best("10.0.0.0")
+        self.assertEqual(node, node3)
+        node = tree.search_best("10.0.0.0/24")
+        self.assertEqual(node, node3)
+        node = tree.search_best("10.0.1.0/24")
+        self.assertEqual(node, node2)
 
-    # def test_05__concurrent_trees(self):
-    #     tree1 = radix.Radix()
-    #     node1_2 = tree1.add("10.0.0.0/16")
-    #     node1_3 = tree1.add("10.0.0.0/24")
-    #     node1_3.data["blah"] = 12345
-    #     tree2 = radix.Radix()
-    #     node2_2 = tree2.add("10.0.0.0/16")
-    #     node2_3 = tree2.add("10.0.0.0/24")
-    #     node2_3.data["blah"] = 45678
-    #     self.assertNotEqual(tree1, tree2)
-    #     self.assertNotEqual(node1_2, node2_2)
-    #     node = tree1.search_best("10.0.1.0/24")
-    #     self.assertEqual(node, node1_2)
-    #     self.assertNotEqual(node, node2_2)
-    #     node = tree2.search_best("20.0.0.0/24")
-    #     self.assertEqual(node, None)
-    #     node = tree2.search_best("10.0.0.10")
-    #     self.assertEqual(node.data["blah"], 45678)
+    def test_05__concurrent_trees(self):
+        tree1 = radix.Radix()
+        node1_2 = tree1.add("10.0.0.0/16")
+        node1_3 = tree1.add("10.0.0.0/24")
+        node1_3.data["blah"] = 12345
+        tree2 = radix.Radix()
+        node2_2 = tree2.add("10.0.0.0/16")
+        node2_3 = tree2.add("10.0.0.0/24")
+        node2_3.data["blah"] = 45678
+        self.assertNotEqual(tree1, tree2)
+        self.assertNotEqual(node1_2, node2_2)
+        node = tree1.search_best("10.0.1.0/24")
+        self.assertEqual(node, node1_2)
+        self.assertNotEqual(node, node2_2)
+        node = tree2.search_best("20.0.0.0/24")
+        self.assertEqual(node, None)
+        node = tree2.search_best("10.0.0.10")
+        self.assertEqual(node.data["blah"], 45678)
 
-    # def test_06__deletes(self):
-    #     tree = radix.Radix()
-    #     node1 = tree.add("10.0.0.0/8")
-    #     self.assertRaises(KeyError, tree.delete, "127.0.0.1")
-    #     self.assertRaises(KeyError, tree.delete, "10.0.0.0/24")
-    #     node = tree.search_best("10.0.0.10")
-    #     self.assertEqual(node, node1)
+    def test_06__deletes(self):
+        tree = radix.Radix()
+        node1 = tree.add("10.0.0.0/8")
+        self.assertRaises(KeyError, tree.delete, "127.0.0.1")
+        self.assertRaises(KeyError, tree.delete, "10.0.0.0/24")
+        node = tree.search_best("10.0.0.10")
+        self.assertEqual(node, node1)
 
-    # def test_07__nodes(self):
-    #     tree = radix.Radix()
-    #     prefixes = [
-    #         "10.0.0.0/8", "127.0.0.1/32",
-    #         "10.1.0.0/16", "10.100.100.100/32",
-    #         "abcd:ef12::/32", "abcd:ef01:2345:6789::/64", "::1/128"
-    #     ]
-    #     prefixes.sort()
-    #     for prefix in prefixes:
-    #         tree.add(prefix)
-    #     nodes = tree.nodes()
-    #     addrs = list(map(lambda x: x.prefix, nodes))
-    #     addrs.sort()
-    #     self.assertEqual(addrs, prefixes)
+    def test_07__nodes(self):
+        tree = radix.Radix()
+        prefixes = [
+            "10.0.0.0/8", "127.0.0.1/32",
+            "10.1.0.0/16", "10.100.100.100/32",
+            "abcd:ef12::/32", "abcd:ef01:2345:6789::/64", "::1/128"
+        ]
+        prefixes.sort()
+        for prefix in prefixes:
+            tree.add(prefix)
+        nodes = tree.nodes()
+        addrs = list(map(lambda x: x.prefix, nodes))
+        addrs.sort()
+        self.assertEqual(addrs, prefixes)
 
-    # def test_08__nodes_empty_tree(self):
-    #     tree = radix.Radix()
-    #     nodes = tree.nodes()
-    #     self.assertEqual(nodes, [])
+    def test_08__nodes_empty_tree(self):
+        tree = radix.Radix()
+        nodes = tree.nodes()
+        self.assertEqual(nodes, [])
 
-    # def test_09__prefixes(self):
-    #     tree = radix.Radix()
-    #     prefixes = [
-    #         "10.0.0.0/8", "127.0.0.1/32",
-    #         "10.1.0.0/16", "10.100.100.100/32",
-    #         "abcd:ef12::/32", "abcd:ef01:2345:6789::/64", "::1/128"
-    #     ]
-    #     prefixes.sort()
-    #     for prefix in prefixes:
-    #         tree.add(prefix)
-    #     addrs = tree.prefixes()
-    #     addrs.sort()
-    #     self.assertEqual(addrs, prefixes)
+    def test_09__prefixes(self):
+        tree = radix.Radix()
+        prefixes = [
+            "10.0.0.0/8", "127.0.0.1/32",
+            "10.1.0.0/16", "10.100.100.100/32",
+            "abcd:ef12::/32", "abcd:ef01:2345:6789::/64", "::1/128"
+        ]
+        prefixes.sort()
+        for prefix in prefixes:
+            tree.add(prefix)
+        addrs = tree.prefixes()
+        addrs.sort()
+        self.assertEqual(addrs, prefixes)
 
-    # def test_10__use_after_free(self):
-    #     tree = radix.Radix()
-    #     node1 = tree.add("10.0.0.0/8")
-    #     del tree
-    #     self.assertEquals(node1.prefix, "10.0.0.0/8")
+    def test_10__use_after_free(self):
+        tree = radix.Radix()
+        node1 = tree.add("10.0.0.0/8")
+        del tree
+        self.assertEquals(node1.prefix, "10.0.0.0/8")
 
-    # def test_11__unique_instance(self):
-    #     tree = radix.Radix()
-    #     node1 = tree.add("10.0.0.0/8")
-    #     node2 = tree.add("10.0.0.0/8")
-    #     self.assertTrue(node1 is node2)
-    #     self.assertTrue(node1.prefix is node2.prefix)
+    def test_11__unique_instance(self):
+        tree = radix.Radix()
+        node1 = tree.add("10.0.0.0/8")
+        node2 = tree.add("10.0.0.0/8")
+        self.assertTrue(node1 is node2)
+        self.assertTrue(node1.prefix is node2.prefix)
 
-    # def test_12__inconsistent_masks4(self):
-    #     tree = radix.Radix()
-    #     node1 = tree.add("10.255.255.255", 28)
-    #     node2 = tree.add(network="10.255.255.240/28")
-    #     node3 = tree.add(network="10.255.255.252", masklen=28)
-    #     self.assertTrue(node1 is node2)
-    #     self.assertTrue(node1 is node3)
-    #     self.assertEquals(node1.prefix, "10.255.255.240/28")
+    def test_12__inconsistent_masks4(self):
+        tree = radix.Radix()
+        node1 = tree.add("10.255.255.255", 28)
+        node2 = tree.add(network="10.255.255.240/28")
+        node3 = tree.add(network="10.255.255.252", masklen=28)
+        self.assertTrue(node1 is node2)
+        self.assertTrue(node1 is node3)
+        self.assertEquals(node1.prefix, "10.255.255.240/28")
 
-    # def test_13__inconsistent_masks6(self):
-    #     tree = radix.Radix()
-    #     node1 = tree.add("dead:beef:1234:5678::", 32)
-    #     node2 = tree.add(network="dead:beef:8888:9999::/32")
-    #     node3 = tree.add(network="dead:beef::", masklen=32)
-    #     self.assertTrue(node1 is node2)
-    #     self.assertTrue(node1 is node3)
-    #     self.assertEquals(node1.prefix, "dead:beef::/32")
+    def test_13__inconsistent_masks6(self):
+        tree = radix.Radix()
+        node1 = tree.add("dead:beef:1234:5678::", 32)
+        node2 = tree.add(network="dead:beef:8888:9999::/32")
+        node3 = tree.add(network="dead:beef::", masklen=32)
+        self.assertTrue(node1 is node2)
+        self.assertTrue(node1 is node3)
+        self.assertEquals(node1.prefix, "dead:beef::/32")
 
-    # def test_14__packed_addresses4(self):
-    #     tree = radix.Radix()
-    #     p = struct.pack('4B', 0xe0, 0x14, 0x0b, 0x40)
-    #     node = tree.add(packed=p, masklen=26)
-    #     self.assertEquals(node.family, socket.AF_INET)
-    #     self.assertEquals(node.prefix, "224.20.11.64/26")
-    #     self.assertEquals(node.packed, p)
+    def test_14__packed_addresses4(self):
+        tree = radix.Radix()
+        p = struct.pack('4B', 0xe0, 0x14, 0x0b, 0x40)
+        node = tree.add(packed=p, masklen=26)
+        self.assertEquals(node.family, socket.AF_INET)
+        self.assertEquals(node.prefix, "224.20.11.64/26")
+        self.assertEquals(node.packed, p)
 
-    # def test_15__packed_addresses6(self):
-    #     tree = radix.Radix()
-    #     p = struct.pack(
-    #         '16B',
-    #         0xde, 0xad, 0xbe, 0xef, 0x12, 0x34, 0x56, 0x78,
-    #         0x9a, 0xbc, 0xde, 0xf0, 0x00, 0x00, 0x00, 0x00)
-    #     node = tree.add(packed=p, masklen=108)
-    #     self.assertEquals(node.family, socket.AF_INET6)
-    #     self.assertEquals(
-    #         node.prefix,
-    #         "dead:beef:1234:5678:9abc:def0::/108")
-    #     self.assertEquals(node.packed, p)
+    def test_15__packed_addresses6(self):
+        tree = radix.Radix()
+        p = struct.pack(
+            '16B',
+            0xde, 0xad, 0xbe, 0xef, 0x12, 0x34, 0x56, 0x78,
+            0x9a, 0xbc, 0xde, 0xf0, 0x00, 0x00, 0x00, 0x00)
+        node = tree.add(packed=p, masklen=108)
+        self.assertEquals(node.family, socket.AF_INET6)
+        self.assertEquals(
+            node.prefix,
+            "dead:beef:1234:5678:9abc:def0::/108")
+        self.assertEquals(node.packed, p)
 
-    # def test_16__bad_addresses(self):
-    #     tree = radix.Radix()
-    #     self.assertRaises(TypeError, tree.add)
-    #     self.assertRaises(ValueError, tree.add, "blah/32")
-    #     self.assertRaises(ValueError, tree.add, "blah", 32)
-    #     self.assertRaises(ValueError, tree.add, "127.0.0.1", -2)
-    #     self.assertRaises(ValueError, tree.add, "127.0.0.1", 64)
-    #     self.assertRaises(ValueError, tree.add, "::", -2)
-    #     self.assertRaises(ValueError, tree.add, "::", 256)
-    #     self.assertEquals(len(tree.nodes()), 0)
+    def test_16__bad_addresses(self):
+        tree = radix.Radix()
+        self.assertRaises(TypeError, tree.add)
+        self.assertRaises(ValueError, tree.add, "blah/32")
+        self.assertRaises(ValueError, tree.add, "blah", 32)
+        self.assertRaises(ValueError, tree.add, "127.0.0.1", -2)
+        self.assertRaises(ValueError, tree.add, "127.0.0.1", 64)
+        self.assertRaises(ValueError, tree.add, "::", -2)
+        self.assertRaises(ValueError, tree.add, "::", 256)
+        self.assertEquals(len(tree.nodes()), 0)
 
-    # def test_17__mixed_address_family(self):
-    #     tree = radix.Radix()
-    #     node1 = tree.add("255.255.255.255", 32)
-    #     node2 = tree.add("ffff::/32")
-    #     node1_o = tree.search_best("255.255.255.255")
-    #     node2_o = tree.search_best("ffff::")
-    #     self.assertTrue(node1 is node1_o)
-    #     self.assertTrue(node2 is node2_o)
-    #     self.assertNotEquals(node1.prefix, node2.prefix)
-    #     self.assertNotEquals(node1.network, node2.network)
-    #     self.assertNotEquals(node1.family, node2.family)
+    def test_17__mixed_address_family(self):
+        tree = radix.Radix()
+        node1 = tree.add("255.255.255.255", 32)
+        node2 = tree.add("ffff::/32")
+        node1_o = tree.search_best("255.255.255.255")
+        node2_o = tree.search_best("ffff::")
+        self.assertTrue(node1 is node1_o)
+        self.assertTrue(node2 is node2_o)
+        self.assertNotEquals(node1.prefix, node2.prefix)
+        self.assertNotEquals(node1.network, node2.network)
+        self.assertNotEquals(node1.family, node2.family)
 
-    # def test_18__iterator(self):
-    #     tree = radix.Radix()
-    #     prefixes = [
-    #         "::1/128", "2000::/16", "2000::/8", "dead:beef::/64",
-    #         "ffff::/16", "10.0.0.0/8", "a00::/8", "255.255.0.0/16",
-    #         "::/0", "0.0.0.0/0"
-    #     ]
-    #     prefixes.sort()
-    #     for prefix in prefixes:
-    #         tree.add(prefix)
-    #     iterprefixes = []
-    #     for node in tree:
-    #         iterprefixes.append(node.prefix)
-    #     iterprefixes.sort()
-    #     self.assertEqual(iterprefixes, prefixes)
+    def test_18__iterator(self):
+        tree = radix.Radix()
+        prefixes = [
+            "::1/128", "2000::/16", "2000::/8", "dead:beef::/64",
+            "ffff::/16", "10.0.0.0/8", "a00::/8", "255.255.0.0/16",
+            "::/0", "0.0.0.0/0"
+        ]
+        prefixes.sort()
+        for prefix in prefixes:
+            tree.add(prefix)
+        iterprefixes = []
+        for node in tree:
+            iterprefixes.append(node.prefix)
+        iterprefixes.sort()
+        self.assertEqual(iterprefixes, prefixes)
 
-    # def test_19__iterate_on_empty(self):
-    #     tree = radix.Radix()
-    #     prefixes = []
-    #     for node in tree:
-    #         prefixes.append(node.prefix)
-    #     self.assertEqual(prefixes, [])
+    def test_19__iterate_on_empty(self):
+        tree = radix.Radix()
+        prefixes = []
+        for node in tree:
+            prefixes.append(node.prefix)
+        self.assertEqual(prefixes, [])
 
-    # def test_20__iterate_and_modify_tree(self):
-    #     tree = radix.Radix()
-    #     prefixes = [
-    #         "::1/128", "2000::/16", "2000::/8", "dead:beef::/64",
-    #         "0.0.0.0/8", "127.0.0.1/32"
-    #     ]
-    #     prefixes.sort()
-    #     for prefix in prefixes:
-    #         tree.add(prefix)
+    def test_20__iterate_and_modify_tree(self):
+        tree = radix.Radix()
+        prefixes = [
+            "::1/128", "2000::/16", "2000::/8", "dead:beef::/64",
+            "0.0.0.0/8", "127.0.0.1/32"
+        ]
+        prefixes.sort()
+        for prefix in prefixes:
+            tree.add(prefix)
 
-    #     def iter_mod(t):
-    #         [t.delete(x.prefix) for x in t]
-    #     self.assertRaises(RuntimeWarning, iter_mod, tree)
+        def iter_mod(t):
+            [t.delete(x.prefix) for x in t]
+        self.assertRaises(RuntimeWarning, iter_mod, tree)
 
-    # def test_21__lots_of_prefixes(self):
-    #     tree = radix.Radix()
-    #     num_nodes_in = 0
-    #     for i in range(0, 128):
-    #         for j in range(0, 128):
-    #             k = ((i + j) % 8) + 24
-    #             node = tree.add("1.%d.%d.0" % (i, j), k)
-    #             node.data["i"] = i
-    #             node.data["j"] = j
-    #             num_nodes_in += 1
+    def test_21__lots_of_prefixes(self):
+        tree = radix.Radix()
+        num_nodes_in = 0
+        for i in range(0, 128):
+            for j in range(0, 128):
+                k = ((i + j) % 8) + 24
+                node = tree.add("1.%d.%d.0" % (i, j), k)
+                node.data["i"] = i
+                node.data["j"] = j
+                num_nodes_in += 1
 
-    #     num_nodes_del = 0
-    #     for i in range(0, 128, 5):
-    #         for j in range(0, 128, 3):
-    #             k = ((i + j) % 8) + 24
-    #             tree.delete("1.%d.%d.0" % (i, j), k)
-    #             num_nodes_del += 1
+        num_nodes_del = 0
+        for i in range(0, 128, 5):
+            for j in range(0, 128, 3):
+                k = ((i + j) % 8) + 24
+                tree.delete("1.%d.%d.0" % (i, j), k)
+                num_nodes_del += 1
 
-    #     num_nodes_out = 0
-    #     for node in tree:
-    #         i = node.data["i"]
-    #         j = node.data["j"]
-    #         k = ((i + j) % 8) + 24
-    #         prefix = "1.%d.%d.0/%d" % (i, j, k)
-    #         self.assertEquals(node.prefix, prefix)
-    #         num_nodes_out += 1
+        num_nodes_out = 0
+        for node in tree:
+            i = node.data["i"]
+            j = node.data["j"]
+            k = ((i + j) % 8) + 24
+            prefix = "1.%d.%d.0/%d" % (i, j, k)
+            self.assertEquals(node.prefix, prefix)
+            num_nodes_out += 1
 
-    #     self.assertEquals(num_nodes_in - num_nodes_del, num_nodes_out)
-    #     self.assertEquals(
-    #         num_nodes_in - num_nodes_del,
-    #         len(tree.nodes()))
+        self.assertEquals(num_nodes_in - num_nodes_del, num_nodes_out)
+        self.assertEquals(
+            num_nodes_in - num_nodes_del,
+            len(tree.nodes()))
 
-    # def test_22__broken_sanitise(self):
-    #     tree = radix.Radix()
-    #     node = tree.add("255.255.255.255/15")
-    #     self.assertEquals(node.prefix, "255.254.0.0/15")
+    def test_22__broken_sanitise(self):
+        tree = radix.Radix()
+        node = tree.add("255.255.255.255/15")
+        self.assertEquals(node.prefix, "255.254.0.0/15")
 
-    # def test_21__pickle(self):
-    #     tree = radix.Radix()
-    #     num_nodes_in = 0
-    #     for i in range(0, 128):
-    #         for j in range(0, 128):
-    #             k = ((i + j) % 8) + 24
-    #             addr = "1.%d.%d.0" % (i, j)
-    #             node = tree.add(addr, k)
-    #             node.data["i"] = i
-    #             node.data["j"] = j
-    #             num_nodes_in += 1
-    #     tree_pickled = pickle.dumps(tree)
-    #     del tree
-    #     tree2 = pickle.loads(tree_pickled)
-    #     for i in range(0, 128):
-    #         for j in range(0, 128):
-    #             k = ((i + j) % 8) + 24
-    #             addr = "1.%d.%d.0" % (i, j)
-    #             node = tree2.search_exact(addr, k)
-    #             self.assertNotEquals(node, None)
-    #             self.assertEquals(node.data["i"], i)
-    #             self.assertEquals(node.data["j"], j)
-    #             node.data["j"] = j
-    #     self.assertEquals(len(tree2.nodes()), num_nodes_in)
+    def test_21__pickle(self):
+        tree = radix.Radix()
+        num_nodes_in = 0
+        for i in range(0, 128):
+            for j in range(0, 128):
+                k = ((i + j) % 8) + 24
+                addr = "1.%d.%d.0" % (i, j)
+                node = tree.add(addr, k)
+                node.data["i"] = i
+                node.data["j"] = j
+                num_nodes_in += 1
+        tree_pickled = pickle.dumps(tree)
+        del tree
+        tree2 = pickle.loads(tree_pickled)
+        for i in range(0, 128):
+            for j in range(0, 128):
+                k = ((i + j) % 8) + 24
+                addr = "1.%d.%d.0" % (i, j)
+                node = tree2.search_exact(addr, k)
+                self.assertNotEquals(node, None)
+                self.assertEquals(node.data["i"], i)
+                self.assertEquals(node.data["j"], j)
+                node.data["j"] = j
+        self.assertEquals(len(tree2.nodes()), num_nodes_in)
 
-    # def test_21__cpickle(self):
-    #     if sys.version_info[0] >= 3:
-    #         return
-    #     tree = radix.Radix()
-    #     num_nodes_in = 0
-    #     for i in range(0, 128):
-    #         for j in range(0, 128):
-    #             k = ((i + j) % 8) + 24
-    #             addr = "1.%d.%d.0" % (i, j)
-    #             node = tree.add(addr, k)
-    #             node.data["i"] = i
-    #             node.data["j"] = j
-    #             num_nodes_in += 1
-    #     tree_pickled = cPickle.dumps(tree)
-    #     del tree
-    #     tree2 = cPickle.loads(tree_pickled)
-    #     for i in range(0, 128):
-    #         for j in range(0, 128):
-    #             k = ((i + j) % 8) + 24
-    #             addr = "1.%d.%d.0" % (i, j)
-    #             node = tree2.search_exact(addr, k)
-    #             self.assertNotEquals(node, None)
-    #             self.assertEquals(node.data["i"], i)
-    #             self.assertEquals(node.data["j"], j)
-    #             node.data["j"] = j
-    #     self.assertEquals(len(tree2.nodes()), num_nodes_in)
+    def test_21__cpickle(self):
+        if sys.version_info[0] >= 3:
+            return
+        tree = radix.Radix()
+        num_nodes_in = 0
+        for i in range(0, 128):
+            for j in range(0, 128):
+                k = ((i + j) % 8) + 24
+                addr = "1.%d.%d.0" % (i, j)
+                node = tree.add(addr, k)
+                node.data["i"] = i
+                node.data["j"] = j
+                num_nodes_in += 1
+        tree_pickled = cPickle.dumps(tree)
+        del tree
+        tree2 = cPickle.loads(tree_pickled)
+        for i in range(0, 128):
+            for j in range(0, 128):
+                k = ((i + j) % 8) + 24
+                addr = "1.%d.%d.0" % (i, j)
+                node = tree2.search_exact(addr, k)
+                self.assertNotEquals(node, None)
+                self.assertEquals(node.data["i"], i)
+                self.assertEquals(node.data["j"], j)
+                node.data["j"] = j
+        self.assertEquals(len(tree2.nodes()), num_nodes_in)
 
     def test_22_search_best(self):
         tree = radix.Radix()


### PR DESCRIPTION
This new method `rnodes = rtree.search_covered("10.123.0.0/16")` allows you to find all nodes within a certain prefix.

Pull contains Python implementation that passes the tests I wrote, plus cursory inspection by @job, but I'm not 100% certain about correctness. Pull contains a C stub that is a copy of `.prefixes()` except it returns nodes, just so I can at least run the tests.

PRing this now to solicit feedback on the Python implementation, so that I can extend the tests if any issues are found, and write the C version then. Of course, if anybody feels like doing the C version, I won't complain ;)