### PR TITLE
Fix search_covered

### DIFF
--- a/radix/_radix.c
+++ b/radix/_radix.c
@@ -538,7 +538,6 @@ Radix_search_covered(RadixObject *self, PyObject *args, PyObject *kw_args)
 
         if ((node = radix_search_node(PICKRT(prefix, self), prefix)) == NULL) {
                 Deref_Prefix(prefix);
-                Py_INCREF(Py_None);
                 return ret;
         }
 

--- a/radix/_radix/radix.c
+++ b/radix/_radix/radix.c
@@ -320,6 +320,7 @@ radix_node_t
             if (node_iter->data != NULL) {
                 if ( ! comp_with_mask(prefix_tochar(node_iter->prefix), prefix_tochar(prefix), bitlen)) {
                     right_mismatch = 1;
+                    break;
                 }
             }
         } RADIX_WALK_END;
@@ -328,6 +329,7 @@ radix_node_t
             if (node_iter->data != NULL) {
                 if ( ! comp_with_mask(prefix_tochar(node_iter->prefix), prefix_tochar(prefix), bitlen)) {
                     left_mismatch = 1;
+                    break;
                 }
             }
         } RADIX_WALK_END;

--- a/radix/_radix/radix.c
+++ b/radix/_radix/radix.c
@@ -300,6 +300,15 @@ radix_node_t
                         return (NULL);
         }
 
+        // comp_with_mask will segfault node->prefix is null
+        // Not entirely sure when this happens, but I think it happens when
+        // no nodes exist above the requested prefix
+        // Right now this solved by seeing if it is null, and then returning
+        // Not 100% sure this is always right, but it passes the tests :-)
+
+        if ( ! node->prefix)
+                return node; // cannot compare
+
         if (comp_with_mask(prefix_tochar(node->prefix), prefix_tochar(prefix), bitlen))
                 return (node);
 

--- a/radix/_radix/radix.c
+++ b/radix/_radix/radix.c
@@ -282,7 +282,6 @@ radix_node_t
         radix_node_t *node;
         u_char *addr;
         u_int bitlen;
-        prefix_t *prefix_cmp;
 
         if (radix->head == NULL)
                 return (NULL);

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -431,6 +431,15 @@ class TestRadix(unittest.TestCase):
             ['10.0.0.0/8', '10.0.0.0/13', '10.0.0.0/31', '11.0.0.0/16'])
 
 
+    def test_26_search_covered_segfault(self):
+        # the following will make py-radix 0.8 segfault
+        tree = radix.Radix()
+        tree.add('193.178.156.0/24')
+        tree.add('193.178.157.0/24')
+
+        tree.search_covered('193.178.158.0/21')
+
+
 
 def main():
     unittest.main()

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -431,7 +431,7 @@ class TestRadix(unittest.TestCase):
             ['10.0.0.0/8', '10.0.0.0/13', '10.0.0.0/31', '11.0.0.0/16'])
 
 
-    def test_26_search_covered_segfault(self):
+    def test_27_search_covered_segfault(self):
         # the following will make py-radix 0.8 segfault
         tree = radix.Radix()
         tree.add('193.178.156.0/24')

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -437,8 +437,9 @@ class TestRadix(unittest.TestCase):
         tree.add('193.178.156.0/24')
         tree.add('193.178.157.0/24')
 
-        tree.search_covered('193.178.158.0/21')
-
+        self.assertEquals(
+            [ n.prefix for n in tree.search_covered('193.178.152.0/21')],
+            [ '193.178.156.0/24', '193.178.157.0/24'])
 
 
 def main():

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -442,6 +442,18 @@ class TestRadix(unittest.TestCase):
             [ '193.178.156.0/24', '193.178.157.0/24'])
 
 
+    def test_28_search_covered_super_node_error(self):
+
+        tree = radix.Radix()
+        tree.add('27.0.100.0/24')
+        tree.add('27.0.101.0/24')
+
+        self.assertEquals(
+            [ n.prefix for n in tree.search_covered('31.3.104.0/21') ],
+            [])
+
+
+
 def main():
     unittest.main()
 


### PR DESCRIPTION
The initial c implementation of search_covered would segfault when node->prefix was null. Fixing this involves checking subtree matching.

There might be more clever way to solve this.