### PR TITLE
Add a search_covering method

### DIFF
--- a/radix/__init__.py
+++ b/radix/__init__.py
@@ -18,6 +18,7 @@ class Radix(object):
         self.search_best = self._radix.search_best
         self.search_worst = self._radix.search_worst
         self.search_covered = self._radix.search_covered
+        self.search_covering = self._radix.search_covering
         self.nodes = self._radix.nodes
         self.prefixes = self._radix.prefixes
 

--- a/radix/radix.py
+++ b/radix/radix.py
@@ -481,6 +481,16 @@ class Radix(object):
         else:
             return self._tree6.search_covered(prefix)
 
+    def search_covering(self, network=None, masklen=None, packed=None):
+        node = self.search_best(network=network, masklen=masklen,
+                                packed=packed)
+        stack = []
+        while node is not None:
+            if node._prefix and node.data is not None:
+                stack.append(node)
+            node = node.parent
+        return stack
+
     def _iter(self, node):
         stack = []
         while node is not None:

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -453,6 +453,28 @@ class TestRadix(unittest.TestCase):
             [])
 
 
+    def test_29_search_covering(self):
+
+        tree = radix.Radix()
+        tree.add('0.0.0.0/2')
+        tree.add('8.9.0.1/32')
+        tree.add('8.9.0.0/16')
+        tree.add('3.178.156.0/24')
+        tree.add('3.178.157.0/24')
+
+        self.assertEquals([n.prefix for n in
+                           tree.search_covering('8.9.0.1/32')],
+                          ['8.9.0.1/32', '8.9.0.0/16', '0.0.0.0/2'])
+        self.assertEquals([n.prefix for n in
+                           tree.search_covering('5.5.5.0/24')],
+                          ['0.0.0.0/2'])
+        self.assertEquals([n.prefix for n in
+                           tree.search_covering('3.178.152.0/21')],
+                          ['0.0.0.0/2'])
+        self.assertEquals([n.prefix for n in
+                           tree.search_covering('205.0.1.0/24')],
+                          [])
+
 
 def main():
     unittest.main()


### PR DESCRIPTION
Return a list of nodes with a less specific (or covering) prefix.