### PR TITLE
Code simplification and optimizations

### DIFF
--- a/radix/_radix/radix.c
+++ b/radix/_radix/radix.c
@@ -349,7 +349,7 @@ radix_node_t
 
 
 /* if inclusive != 0, "best" may be the given prefix itself */
-static radix_node_t
+radix_node_t
 *radix_search_best2(radix_tree_t *radix, prefix_t *prefix, int inclusive)
 {
         radix_node_t *node;
@@ -402,7 +402,7 @@ radix_node_t
 }
 
 /* if inclusive != 0, "worst" may be the given prefix itself */
-static radix_node_t
+radix_node_t
 *radix_search_worst2(radix_tree_t *radix, prefix_t *prefix, int inclusive)
 {
         radix_node_t *node;

--- a/radix/_radix/radix.c
+++ b/radix/_radix/radix.c
@@ -71,6 +71,9 @@
  * $MRTId: defs.h,v 1.1.1.1 2000/08/14 18:46:10 labovit Exp $
  */
 #define BIT_TEST(f, b)  ((f) & (b))
+#define BIT_TEST_SEARCH_BIT(addr, bit) \
+        BIT_TEST((addr)[(bit) >> 3], 0x80 >> ((bit) & 0x07))
+#define BIT_TEST_SEARCH(addr, node) BIT_TEST_SEARCH_BIT(addr, (node)->bit)
 
 /*
  * Originally from MRT include/mrt.h
@@ -255,7 +258,7 @@ radix_node_t
         bitlen = prefix->bitlen;
 
         while (node->bit < bitlen) {
-                if (BIT_TEST(addr[node->bit >> 3], 0x80 >> (node->bit & 0x07)))
+                if (BIT_TEST_SEARCH(addr, node))
                         node = node->r;
                 else
                         node = node->l;
@@ -291,7 +294,7 @@ radix_node_t
         bitlen = prefix->bitlen;
 
         while (node->bit < bitlen) {
-                if (BIT_TEST(addr[node->bit >> 3], 0x80 >> (node->bit & 0x07)))
+                if (BIT_TEST_SEARCH(addr, node))
                         node = node->r;
                 else
                         node = node->l;
@@ -368,7 +371,7 @@ radix_node_t
         while (node->bit < bitlen) {
                 if (node->prefix)
                         stack[cnt++] = node;
-                if (BIT_TEST(addr[node->bit >> 3], 0x80 >> (node->bit & 0x07)))
+                if (BIT_TEST_SEARCH(addr, node))
                         node = node->r;
                 else
                         node = node->l;
@@ -422,7 +425,7 @@ radix_node_t
         while (node->bit < bitlen) {
                 if (node->prefix)
                         stack[cnt++] = node;
-                if (BIT_TEST(addr[node->bit >> 3], 0x80 >> (node->bit & 0x07)))
+                if (BIT_TEST_SEARCH(addr, node))
                         node = node->r;
                 else
                         node = node->l;
@@ -481,8 +484,7 @@ radix_node_t
         node = radix->head;
 
         while (node->bit < bitlen || node->prefix == NULL) {
-                if (node->bit < radix->maxbits && BIT_TEST(addr[node->bit >> 3],
-                    0x80 >> (node->bit & 0x07))) {
+                if (node->bit < radix->maxbits && BIT_TEST_SEARCH(addr, node)) {
                         if (node->r == NULL)
                                 break;
                         node = node->r;
@@ -537,8 +539,7 @@ radix_node_t
 
         if (node->bit == differ_bit) {
                 new_node->parent = node;
-                if (node->bit < radix->maxbits && BIT_TEST(addr[node->bit >> 3],
-                    0x80 >> (node->bit & 0x07)))
+                if (node->bit < radix->maxbits && BIT_TEST_SEARCH(addr, node))
                         node->r = new_node;
                 else
                         node->l = new_node;
@@ -546,8 +547,8 @@ radix_node_t
                 return (new_node);
         }
         if (bitlen == differ_bit) {
-                if (bitlen < radix->maxbits && BIT_TEST(test_addr[bitlen >> 3],
-                    0x80 >> (bitlen & 0x07)))
+                if (bitlen < radix->maxbits &&
+                    BIT_TEST_SEARCH_BIT(test_addr, bitlen))
                         new_node->r = node;
                 else
                         new_node->l = node;
@@ -571,8 +572,7 @@ radix_node_t
                 glue->data = NULL;
                 radix->num_active_node++;
                 if (differ_bit < radix->maxbits &&
-                    BIT_TEST(addr[differ_bit >> 3],
-                    0x80 >> (differ_bit & 0x07))) {
+                    BIT_TEST_SEARCH_BIT(addr, differ_bit)) {
                         glue->r = new_node;
                         glue->l = node;
                 } else {

--- a/radix/_radix/radix.c
+++ b/radix/_radix/radix.c
@@ -683,16 +683,13 @@ sanitise_mask(u_char *addr, u_int masklen, u_int maskbits)
 }
 
 prefix_t
-*prefix_pton(const char *string, long len, const char **errmsg)
+*prefix_pton_ex(prefix_t *ret, const char *string, long len, const char **errmsg)
 {
         char save[256], *cp, *ep;
         struct addrinfo hints, *ai;
         void *addr;
-        prefix_t *ret;
         size_t slen;
         int r;
-
-        ret = NULL;
 
         /* Copy the string to parse, because we modify it */
         if ((slen = strlen(string) + 1) > sizeof(save)) {
@@ -750,7 +747,7 @@ prefix_t
                 goto out;
         }
 
-        ret = New_Prefix2(ai->ai_addr->sa_family, addr, len, NULL);
+        ret = New_Prefix2(ai->ai_addr->sa_family, addr, len, ret);
         if (ret == NULL)
                 *errmsg = "New_Prefix2 failed";
 out:
@@ -759,7 +756,13 @@ out:
 }
 
 prefix_t
-*prefix_from_blob(u_char *blob, int len, int prefixlen)
+*prefix_pton(const char *string, long len, const char **errmsg)
+{
+	return (prefix_pton_ex(NULL, string, len, errmsg));
+}
+
+prefix_t
+*prefix_from_blob_ex(prefix_t *ret, u_char *blob, int len, int prefixlen)
 {
         int family, maxprefix;
 
@@ -782,7 +785,13 @@ prefix_t
                 prefixlen = maxprefix;
         if (prefixlen < 0 || prefixlen > maxprefix)
                 return NULL;
-        return (New_Prefix2(family, blob, prefixlen, NULL));
+        return (New_Prefix2(family, blob, prefixlen, ret));
+}
+
+prefix_t
+*prefix_from_blob(u_char *blob, int len, int prefixlen)
+{
+	return (prefix_from_blob_ex(NULL, blob, len, prefixlen));
 }
 
 const char *

--- a/radix/_radix/radix.c
+++ b/radix/_radix/radix.c
@@ -90,8 +90,7 @@
 #define RADIX_SEARCH_FOREACH_INCLUSIVE(node, head, prefix) \
         for ((node) = (head); \
              (node) != NULL && (node)->bit <= (prefix)->bitlen; \
-             (node) = (((node)->bit == (prefix)->bitlen) ? NULL : \
-                       BIT_TEST_SEARCH(prefix_touchar(prefix), node) ? (node)->r : (node)->l))
+             (node) = BIT_TEST_SEARCH(prefix_touchar(prefix), node) ? (node)->r : (node)->l)
 
 #define RADIX_PHEAD_BY_PREFIX(tree, prefix) \
         ((prefix)->family == AF_INET ? &(tree)->head_ipv4 : &(tree)->head_ipv6)

--- a/radix/_radix/radix.c
+++ b/radix/_radix/radix.c
@@ -199,7 +199,7 @@ radix_tree_t
  * if func is supplied, it will be called as func(node->data)
  * before deleting the node
  */
-static void
+void
 Clear_Radix(radix_tree_t *radix, rdx_cb_t func, void *cbctx)
 {
         if (radix->head) {

--- a/radix/_radix/radix.c
+++ b/radix/_radix/radix.c
@@ -267,8 +267,8 @@ radix_node_t
         if (node->bit > bitlen || node->prefix == NULL)
                 return (NULL);
 
-        if (comp_with_mask(prefix_tochar(node->prefix),
-            prefix_tochar(prefix), bitlen))
+        if (comp_with_mask(prefix_touchar(node->prefix),
+            prefix_touchar(prefix), bitlen))
                 return (node);
 
         return (NULL);
@@ -302,7 +302,7 @@ radix_node_t
 
         // if the node has a prefix we can (and must to avoid false negatives) check directly
         if (node->prefix) {
-                if (comp_with_mask(prefix_tochar(node->prefix), prefix_tochar(prefix), bitlen))
+                if (comp_with_mask(prefix_touchar(node->prefix), prefix_touchar(prefix), bitlen))
                         return (node);
                 else
                         return (NULL);
@@ -318,7 +318,7 @@ radix_node_t
 
         RADIX_WALK(node->r, node_iter) {
             if (node_iter->data != NULL) {
-                if ( ! comp_with_mask(prefix_tochar(node_iter->prefix), prefix_tochar(prefix), bitlen)) {
+                if ( ! comp_with_mask(prefix_touchar(node_iter->prefix), prefix_touchar(prefix), bitlen)) {
                     right_mismatch = 1;
                     break;
                 }
@@ -327,7 +327,7 @@ radix_node_t
 
         RADIX_WALK(node->l, node_iter) {
             if (node_iter->data != NULL) {
-                if ( ! comp_with_mask(prefix_tochar(node_iter->prefix), prefix_tochar(prefix), bitlen)) {
+                if ( ! comp_with_mask(prefix_touchar(node_iter->prefix), prefix_touchar(prefix), bitlen)) {
                     left_mismatch = 1;
                     break;
                 }
@@ -386,8 +386,8 @@ static radix_node_t
 
         while (--cnt >= 0) {
                 node = stack[cnt];
-                if (comp_with_mask(prefix_tochar(node->prefix),
-                    prefix_tochar(prefix), node->prefix->bitlen) &&
+                if (comp_with_mask(prefix_touchar(node->prefix),
+                    prefix_touchar(prefix), node->prefix->bitlen) &&
                     node->prefix->bitlen <= bitlen)
                         return (node);
         }
@@ -410,7 +410,7 @@ static radix_node_t
         u_char *addr;
         u_int bitlen;
         int cnt = 0;
-        int iterator = 0;
+        int iterator;
 
         if (radix->head == NULL)
                 return (NULL);
@@ -438,10 +438,10 @@ static radix_node_t
         if (cnt <= 0)
                 return (NULL);
         
-        for (iterator; iterator < cnt; ++iterator) {
+        for (iterator = 0; iterator < cnt; ++iterator) {
                 node = stack[iterator];
-                if (comp_with_mask(prefix_tochar(node->prefix),
-                    prefix_tochar(prefix), node->prefix->bitlen)) 
+                if (comp_with_mask(prefix_touchar(node->prefix),
+                    prefix_touchar(prefix), node->prefix->bitlen)) 
                         return (node);
         }
         return (NULL);

--- a/radix/_radix/radix.h
+++ b/radix/_radix/radix.h
@@ -116,6 +116,7 @@ typedef struct _radix_tree_t {
 
 /* Type of callback function */
 typedef void (*rdx_cb_t)(radix_node_t *, void *);
+typedef int (*rdx_search_cb_t)(radix_node_t *, void *);
 
 radix_tree_t *New_Radix(void);
 void Destroy_Radix(radix_tree_t *radix, rdx_cb_t func, void *cbctx);
@@ -128,6 +129,9 @@ radix_node_t *radix_search_best(radix_tree_t *radix, prefix_t *prefix);
 radix_node_t *radix_search_best2(radix_tree_t *radix, prefix_t *prefix, int inclusive);
 radix_node_t *radix_search_worst(radix_tree_t *radix, prefix_t *prefix);
 radix_node_t *radix_search_worst2(radix_tree_t *radix, prefix_t *prefix, int inclusive);
+int radix_search_covering(radix_tree_t *radix, prefix_t *prefix, rdx_search_cb_t func, void *cbctx);
+int radix_search_covered(radix_tree_t *radix, prefix_t *prefix, rdx_search_cb_t func, void *cbctx, int inclusive);
+int radix_search_intersect(radix_tree_t *radix, prefix_t *prefix, rdx_search_cb_t func, void *cbctx);
 void radix_process(radix_tree_t *radix, rdx_cb_t func, void *cbctx);
 
 #define RADIX_MAXBITS 128

--- a/radix/_radix/radix.h
+++ b/radix/_radix/radix.h
@@ -109,8 +109,8 @@ typedef struct _radix_node_t {
 } radix_node_t;
 
 typedef struct _radix_tree_t {
-        radix_node_t *head;
-        u_int maxbits;                  /* for IP, 32 bit addresses */
+        radix_node_t *head_ipv4;
+        radix_node_t *head_ipv6;
         int num_active_node;            /* for debug purpose */
 } radix_tree_t;
 
@@ -155,6 +155,25 @@ void radix_process(radix_tree_t *radix, rdx_cb_t func, void *cbctx);
                         } \
                 } \
         } while (0)
+
+#define RADIX_TREE_WALK(Xtree, Xnode) \
+        do { \
+                radix_node_t *Xheads[] = { \
+                        (Xtree)->head_ipv4, \
+                        (Xtree)->head_ipv6, \
+                }; \
+                radix_node_t **Xpnode = &Xnode; \
+                unsigned Xi; \
+                for (Xi = 0; Xi < sizeof(Xheads) / sizeof(Xheads[0]); Xi++) { \
+                        RADIX_WALK(Xheads[Xi], Xnode)
+
+#define RADIX_TREE_WALK_END \
+                        RADIX_WALK_END; \
+                        if (*Xpnode) \
+                                break; \
+                } \
+        } while (0)
+
 
 /* Local additions */
 

--- a/radix/_radix/radix.h
+++ b/radix/_radix/radix.h
@@ -124,7 +124,9 @@ void radix_remove(radix_tree_t *radix, radix_node_t *node);
 radix_node_t *radix_search_node(radix_tree_t *radix, prefix_t *prefix);
 radix_node_t *radix_search_exact(radix_tree_t *radix, prefix_t *prefix);
 radix_node_t *radix_search_best(radix_tree_t *radix, prefix_t *prefix);
+radix_node_t *radix_search_best2(radix_tree_t *radix, prefix_t *prefix, int inclusive);
 radix_node_t *radix_search_worst(radix_tree_t *radix, prefix_t *prefix);
+radix_node_t *radix_search_worst2(radix_tree_t *radix, prefix_t *prefix, int inclusive);
 void radix_process(radix_tree_t *radix, rdx_cb_t func, void *cbctx);
 
 #define RADIX_MAXBITS 128

--- a/radix/_radix/radix.h
+++ b/radix/_radix/radix.h
@@ -119,6 +119,7 @@ typedef void (*rdx_cb_t)(radix_node_t *, void *);
 
 radix_tree_t *New_Radix(void);
 void Destroy_Radix(radix_tree_t *radix, rdx_cb_t func, void *cbctx);
+void Clear_Radix(radix_tree_t *radix, rdx_cb_t func, void *cbctx);
 radix_node_t *radix_lookup(radix_tree_t *radix, prefix_t *prefix);
 void radix_remove(radix_tree_t *radix, radix_node_t *node);
 radix_node_t *radix_search_node(radix_tree_t *radix, prefix_t *prefix);

--- a/radix/_radix/radix.h
+++ b/radix/_radix/radix.h
@@ -157,6 +157,8 @@ void radix_process(radix_tree_t *radix, rdx_cb_t func, void *cbctx);
 
 prefix_t *prefix_pton(const char *string, long len, const char **errmsg);
 prefix_t *prefix_from_blob(u_char *blob, int len, int prefixlen);
+prefix_t *prefix_pton_ex(prefix_t *prefix, const char *string, long len, const char **errmsg);
+prefix_t *prefix_from_blob_ex(prefix_t *prefix, u_char *blob, int len, int prefixlen);
 const char *prefix_addr_ntop(prefix_t *prefix, char *buf, size_t len);
 const char *prefix_ntop(prefix_t *prefix, char *buf, size_t len);
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -415,11 +415,11 @@ class TestRadix(unittest.TestCase):
             [n.prefix for n in tree.search_covered('11.0.0.0/8')],
             ['11.0.0.0/16'])
         self.assertEquals(
-            [n.prefix for n in tree.search_covered('10.0.0.0/9')],
+            sorted([n.prefix for n in tree.search_covered('10.0.0.0/9')]),
             ['10.0.0.0/13', '10.0.0.0/31'])
         self.assertEquals(
-            [n.prefix for n in tree.search_covered('10.0.0.0/8')],
-            ['10.0.0.0/8', '10.0.0.0/13', '10.0.0.0/31'])
+            sorted([n.prefix for n in tree.search_covered('10.0.0.0/8')]),
+            ['10.0.0.0/13', '10.0.0.0/31', '10.0.0.0/8'])
         self.assertEquals(
             [n.prefix for n in tree.search_covered('11.0.0.0/8')],
             ['11.0.0.0/16'])
@@ -427,8 +427,8 @@ class TestRadix(unittest.TestCase):
             [n.prefix for n in tree.search_covered('21.0.0.0/8')],
             [])
         self.assertEquals(
-            [n.prefix for n in tree.search_covered('0.0.0.0/0')],
-            ['10.0.0.0/8', '10.0.0.0/13', '10.0.0.0/31', '11.0.0.0/16'])
+            sorted([n.prefix for n in tree.search_covered('0.0.0.0/0')]),
+            ['10.0.0.0/13', '10.0.0.0/31', '10.0.0.0/8', '11.0.0.0/16'])
 
 
     def test_27_search_covered_segfault(self):


### PR DESCRIPTION
I'm using C part of py-radix in my projects. So, I need all the algorithm to be in a separate library. For now, some useful functions (Radix_search_covered(), for example) are not parts of a radix library but are parts of C-Python glue. Some are just private (static) functions.

So, the main target was to extend C radix library with new functionality. Other things done:
- Removed code duplication in many cases (introduced some useful macroses)
- Added prefix_pton_ex() & prefix_from_blob_ex() to allow to not allocate heap memory for prefix to use search functions
- Reimplemented radix_search_covered() with improved algorithm