### PR TITLE
Fix issue 26

### DIFF
--- a/radix/_radix/radix.c
+++ b/radix/_radix/radix.c
@@ -505,7 +505,7 @@ radix_search_covered(radix_tree_t *radix, prefix_t *prefix, rdx_search_cb_t func
 
         stack[0].state = RADIX_STATE_LEFT;
         stack[0].node = node;
-        stack[0].checked = (node == prefixed_node);
+        stack[0].checked = (node == prefixed_node && node->bit >= prefix->bitlen);
         stackpos = 0;
 
         while (stackpos >= 0) {

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -410,19 +410,24 @@ class TestRadix(unittest.TestCase):
         tree.add('10.0.0.0/13')
         tree.add('10.0.0.0/31')
         tree.add('11.0.0.0/16')
+        tree.add('10.30.2.1/32')
+        tree.add('10.30.2.0/25')
         tree.add('0.0.0.0/0')
         self.assertEquals(
             [n.prefix for n in tree.search_covered('11.0.0.0/8')],
             ['11.0.0.0/16'])
         self.assertEquals(
             sorted([n.prefix for n in tree.search_covered('10.0.0.0/9')]),
-            ['10.0.0.0/13', '10.0.0.0/31'])
+            ['10.0.0.0/13', '10.0.0.0/31', '10.30.2.0/25', '10.30.2.1/32'])
         self.assertEquals(
             sorted([n.prefix for n in tree.search_covered('10.0.0.0/8')]),
-            ['10.0.0.0/13', '10.0.0.0/31', '10.0.0.0/8'])
+            ['10.0.0.0/13', '10.0.0.0/31', '10.0.0.0/8', '10.30.2.0/25', '10.30.2.1/32'])
         self.assertEquals(
             [n.prefix for n in tree.search_covered('11.0.0.0/8')],
             ['11.0.0.0/16'])
+        self.assertEquals(
+            [n.prefix for n in tree.search_covered('10.30.2.64/32')],
+            [])
         self.assertEquals(
             [n.prefix for n in tree.search_covered('21.0.0.0/8')],
             [])
@@ -431,7 +436,7 @@ class TestRadix(unittest.TestCase):
             [])
         self.assertEquals(
             sorted([n.prefix for n in tree.search_covered('0.0.0.0/0')]),
-            ['0.0.0.0/0', '10.0.0.0/13', '10.0.0.0/31', '10.0.0.0/8', '11.0.0.0/16'])
+            ['0.0.0.0/0', '10.0.0.0/13', '10.0.0.0/31', '10.0.0.0/8', '10.30.2.0/25', '10.30.2.1/32', '11.0.0.0/16'])
 
     def test_27_search_covered_segfault(self):
         # the following will make py-radix 0.8 segfault


### PR DESCRIPTION
radix_search_covered(): don't suppress COMP_NODE_PREFIX call for wider prefixes

The root node of a subtree to walk may have a prefix wider than requested.
So, we have to call COMP_NODE_PREFIX() for each nearest prefix of the subtree
in the case.