### PR TITLE
Radix_parent(): bug fix

### DIFF
--- a/radix/_radix.c
+++ b/radix/_radix.c
@@ -117,10 +117,9 @@ RadixNode_dealloc(RadixNodeObject *self)
 static PyObject *
 Radix_parent(RadixNodeObject *self, void *closure)
 {
-PyObject *ret;
+        PyObject *ret;
         radix_node_t *node;
         node = self->rn;
-        ret = Py_None;
         /* walk up through parent to find parent node with data */
         for ( ; ; )
         {
@@ -131,13 +130,13 @@ PyObject *ret;
                         {
                                 ret = node->data;
                                 Py_XINCREF(ret);
-                                break;
+                                return ret;
                         }
                 }
                 else
                         break;
         }
-        return ret;
+        Py_RETURN_NONE;
 }
 static PyMemberDef RadixNode_members[] = {
         {"data",        T_OBJECT, offsetof(RadixNodeObject, user_attr), READONLY},

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,11 @@ if not IS_PYPY and not RADIX_NO_EXT:
     extra_kwargs['ext_modules'] = [radix]
 
 
+tests_require = ['nose', 'coverage']
+if sys.version_info < (2, 7):
+    tests_require.append('unittest2')
+
+
 setup(
     name='py-radix',
     version='0.9.5',
@@ -50,7 +55,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
     ],
-    tests_require=['nose', 'coverage'],
+    tests_require=tests_require,
     packages=find_packages(exclude=['tests', 'tests.*']),
     test_suite='nose.collector',
     **extra_kwargs


### PR DESCRIPTION
When Radix_parent function returned Py_NONE, there was no corresponding
Py_INCREF call. Hence, at some point Python crashed trying to deallocate
None object.