### PR TITLE
Fixed syntax/linker issues when using Microsoft Visual C++ Compiler for Python 2.7

### DIFF
--- a/radix/_radix/radix.c
+++ b/radix/_radix/radix.c
@@ -297,7 +297,9 @@ radix_node_t
 radix_node_t
 *radix_search_node(radix_tree_t *radix, prefix_t *prefix)
 {
-        radix_node_t *node, *head;
+        radix_node_t *node, *head, *node_iter;
+        int right_mismatch = 0;
+        int left_mismatch = 0;
         u_int bitlen;
 
         if ((head = RADIX_HEAD_BY_PREFIX(radix, prefix)) == NULL)
@@ -322,9 +324,6 @@ radix_node_t
         // When this happens we have to check the two subtrees, if a subtree does not match, that part should
         // not be returned. If both match the entire node should be returned. If none match, null is returned.
 
-        int right_mismatch = 0;
-        int left_mismatch = 0;
-        radix_node_t *node_iter;
 
         RADIX_WALK(node->r, node_iter) {
             if (node_iter->data != NULL) {

--- a/radix/_radix/radix.h
+++ b/radix/_radix/radix.h
@@ -63,6 +63,7 @@
 #if defined(_MSC_VER)
 #include <winsock2.h>
 #include <ws2tcpip.h>
+#pragma comment(lib,"ws2_32.lib")
 #else
 # include <sys/types.h>
 # include <sys/socket.h>

--- a/radix/_radix/radix.h
+++ b/radix/_radix/radix.h
@@ -77,7 +77,6 @@
 typedef unsigned __int8         u_int8_t;
 typedef unsigned __int16        u_int16_t;
 typedef unsigned __int32        u_int32_t;
-const char *inet_ntop(int af, const void *src, char *dst, size_t size);
 size_t strlcpy(char *dst, const char *src, size_t size);
 #endif
 


### PR DESCRIPTION
I had issues when doing a pip install py-radix or manually compiling the C Extensions on a Windows machine using python setup.py build. This commit solves that issue when using MSVC++ as a target compiler.

Edit: with Python 2.7.12 64bit.

Please review.

It seems 32bit will have the same issues and requires the above merge + doing something with the inet_ntop reference in radix/_radix/radix.h.

