### PR TITLE
Added Windows support with win_inet_pton

### DIFF
--- a/radix/radix.py
+++ b/radix/radix.py
@@ -1,3 +1,6 @@
+import sys
+if sys.platform.startswith('win'):
+    import win_inet_pton
 from socket import (getaddrinfo, gaierror,
                     inet_pton, inet_ntop, AF_INET, AF_INET6, SOCK_RAW,
                     AI_NUMERICHOST)

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,9 @@ setup(
     ],
     tests_require=tests_require,
     packages=find_packages(exclude=['tests', 'tests.*']),
+    install_requires=[
+        'win-inet-pton;platform_system=="Windows"'
+    ],
     test_suite='nose.collector',
     **extra_kwargs
 )


### PR DESCRIPTION
I found this in the 'Issues' and decided to provide a fix.  I know it's not preferable to have the external dependency on 'win_inet_pton', but that was the only way I could get it working.  If this isn't ideal, I can just a blurb to the README for Windows users to note that an install and conditional include of 'win_inet_pton" is required.