### PR TITLE
Include regression tests in PyPI tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE
 include README.rst
 include radix/_radix/*
+recursive-include tests/ *


### PR DESCRIPTION
In OpenBSD we use regression tests to make sure an update of dependencies don't break anything. This patch will include tests in the PyPI tarball for future releases.