### PR TITLE
feat(radix): Reduce memory footprint of the C implementation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,14 @@
 py-radix
 ========
 
-.. image:: https://travis-ci.org/mjschultz/py-radix.svg?branch=master
-   :target: https://travis-ci.org/mjschultz/py-radix
+Fork of the original library to reduce the memory footprint of the C implementation.
 
-.. image:: https://coveralls.io/repos/mjschultz/py-radix/badge.png?branch=master
-   :target: https://coveralls.io/r/mjschultz/py-radix?branch=master
+In order to reduce the memory usage the following attributes have been removed from the `Node` objects:
+
+  * network
+  * prefix
+
+The `data` object is now `None` by default instead of being an empty dict. It can be used to store any type of data.
 
 py-radix implements the radix tree data structure for the storage and
 retrieval of IPv4 and IPv6 network prefixes.
@@ -37,7 +40,9 @@ Usage
 
 A simple example that demonstrates most of the features: ::
 
+	import socket
 	import radix
+
 
 	# Create a new tree
 	rtree = radix.Radix()
@@ -45,7 +50,7 @@ A simple example that demonstrates most of the features: ::
 	# Adding a node returns a RadixNode object. You can create
 	# arbitrary members in its 'data' dict to store your data
 	rnode = rtree.add("10.0.0.0/8")
-	rnode.data["blah"] = "whatever you want"
+	rnode.data = {"blah": "whatever you want"}
 
 	# You can specify nodes as CIDR addresses, or networks with
 	# separate mask lengths. The following three invocations are
@@ -59,16 +64,16 @@ A simple example that demonstrates most of the features: ::
 	# functions. In this case, the radix module will assume that
 	# a four-byte address is an IPv4 address and a sixteen-byte
 	# address is an IPv6 address. For example:
-	binary_addr = inet_ntoa("172.18.22.0")
+	binary_addr = socket.inet_aton("172.18.22.0")
 	rnode = rtree.add(packed = binary_addr, masklen = 23)
 
 	# Exact search will only return prefixes you have entered
 	# You can use all of the above ways to specify the address
 	rnode = rtree.search_exact("10.0.0.0/8")
 	# Get your data back out
-	print rnode.data["blah"]
+	print(rnode.data["blah"])
 	# Use a packed address
-	addr = socket.inet_ntoa("10.0.0.0")
+	addr = socket.inet_aton("10.0.0.0")
 	rnode = rtree.search_exact(packed = addr, masklen = 8)
 
 	# Best-match search will return the longest matching prefix
@@ -85,11 +90,9 @@ A simple example that demonstrates most of the features: ::
 	rnodes = rtree.search_covered("10.123.0.0/16")
 
 	# There are a couple of implicit members of a RadixNode:
-	print rnode.network	# -> "10.0.0.0"
-	print rnode.prefix	# -> "10.0.0.0/8"
-	print rnode.prefixlen	# -> 8
-	print rnode.family	# -> socket.AF_INET
-	print rnode.packed	# -> '\n\x00\x00\x00'
+	print(rnode.family)	# -> socket.AF_INET
+	print(rnode.packed)	# -> '\n\x00\x00\x00'
+	print(rnode.data)  # -> {'blah': 'whatever you want'}
 
 	# IPv6 prefixes are fully supported in the same tree
 	rnode = rtree.add("2001:DB8::/3")
@@ -98,11 +101,7 @@ A simple example that demonstrates most of the features: ::
 	# Use the nodes() method to return all RadixNodes created
 	nodes = rtree.nodes()
 	for rnode in nodes:
-		print rnode.prefix
-
-	# The prefixes() method will return all the prefixes (as a
-	# list of strings) that have been entered
-	prefixes = rtree.prefixes()
+		print(rnode.packed)
 
 	# You can also directly iterate over the tree itself
 	# this would save some memory if the tree is big
@@ -111,7 +110,7 @@ A simple example that demonstrates most of the features: ::
 	# receive a RuntimeWarning. Changing a node's data dict
 	# is permitted.
 	for rnode in rtree:
-  		print rnode.prefix
+		print(rnode.packed)
 
 
 License


### PR DESCRIPTION
Try to reduce the memory foot print of the C  implementation by:

* Removing `network` and `prefix` from the struct keeping representing a node. Both are of type `char[256]` and it can take a bit of memory when have a lot of elements.
* Setting the `data` attribute to `NULL` by default and make it read-wrtie. An empty python dict takes 240 bytes. This is a lot. It is now possible to store any type of value in `data`.

To not break the `prefixes()` method the prefixes are now calculated from the packed value, the family and the prefix length on the fly.

 I decided to keep `family` and `prefixlen` in the struct so we can recreate ranges from the python side:
```python
"{}/{}".format(
    socket.inet_ntop(rnode.family, rnode.packed),
    rnode.prefixlen
)
```