### PR TITLE
 Add poweron architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: python
 
+arch:
+  - amd64
+  - ppc64le
 sudo: false
 
 python:
   - "pypy"
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
 
@@ -17,6 +19,8 @@ matrix:
   exclude:
     - python: "pypy"  # pypy will always build without extension
       env: RADIX_NO_EXT=false
+    - python: "pypy"  #poweron support exclude
+      arch: ppc64le
 
 install:
   - pip install coveralls 


### PR DESCRIPTION
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing,We typically build applications for customers and ISVs, and while we don't use this package directly, 
we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or third level dependency and couldn't tell you explicitly which features we use or our usage model,For more info tag @gerrith3.

Removed py3.3 since its not supported for amd64 and ppc64le.