### PR TITLE
Change incompatible pointer type from RadixNodeObject to PyObject

### DIFF
--- a/radix/_radix.c
+++ b/radix/_radix.c
@@ -524,7 +524,7 @@ add_node_to_list(radix_node_t *node, void *arg)
         PyObject *ret = arg;
 
         if (node->data != NULL)
-                PyList_Append(ret, ((RadixNodeObject *)node->data));
+                PyList_Append(ret, ((PyObject *)node->data));
         return (0);
 }
 


### PR DESCRIPTION
Since GCC 14 implicitly casting all pointer types to all other pointer types is no longer allowed. This behavior is now restricted to the `void *` type and its qualified variations. According to the Python 3 documentation, all object types are extensions of the `PyObject` type. And it looks like the `RadixNodeObject` should meet the conditions to be a proper Python object.

See also:
 - https://gcc.gnu.org/gcc-14/porting_to.html#warnings-as-errors
 - https://docs.python.org/3/c-api/list.html#c.PyList_Append
 - https://docs.python.org/3/c-api/structures.html#c.PyObject

Fixes: #57

Thanks to @musicinmybrain and @mbattista for their input and suggestions.