### PR TITLE
Switch to GitHub Actions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,58 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python package
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, ubuntu-latest]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        exclude:
+        - os: ubuntu-latest
+          python-version: 3.6
+        - os: ubuntu-20.04
+          python-version: 3.7
+        - os: ubuntu-20.04
+          python-version: 3.8
+        - os: ubuntu-20.04
+          python-version: 3.9
+        - os: ubuntu-20.04
+          python-version: 3.10
+        - os: ubuntu-20.04
+          python-version: 3.11
+        - os: ubuntu-20.04
+          python-version: 3.12
+        - os: ubuntu-20.04
+          python-version: 3.13
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # Stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # For now, treat all errors as warnings using --exit-zero
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: pytest

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 py-radix
 ========
 
-.. image:: https://travis-ci.org/mjschultz/py-radix.svg?branch=master
-   :target: https://travis-ci.org/mjschultz/py-radix
+.. image:: https://github.com/mjschultz/py-radix/actions/workflows/python-package.yml/badge.svg
+   :target: https://github.com/mjschultz/py-radix/actions/workflows/python-package.yml
 
 .. image:: https://coveralls.io/repos/mjschultz/py-radix/badge.png?branch=master
    :target: https://coveralls.io/r/mjschultz/py-radix?branch=master

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,6 @@ if not IS_PYPY and not RADIX_NO_EXT:
 
 
 tests_require = ['nose', 'coverage']
-if sys.version_info < (2, 7):
-    tests_require.append('unittest2')
 
 
 setup(
@@ -47,12 +45,15 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: System :: Networking',
         'License :: OSI Approved :: BSD License',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13'
     ],
     tests_require=tests_require,
     packages=find_packages(exclude=['tests', 'tests.*']),

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -22,25 +22,13 @@ import radix
 import socket
 import struct
 import sys
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
-if sys.version_info < (3, 2):
-    # for 2.x
-    import cPickle
-    t14_packed_addr = '\xe0\x14\x0b@'
-    t15_packed_addr = ('\xde\xad\xbe\xef\x124Vx'
-                       '\x9a\xbc\xde\xf0\x00\x00\x00\x00')
-    range = xrange
-else:
-    # for Py3K
-    t14_packed_addr = struct.pack('4B', 0xe0, 0x14, 0x0b, 0x40)
-    t15_packed_addr = struct.pack(
-        '16B',
-        0xde, 0xad, 0xbe, 0xef, 0x12, 0x34, 0x56, 0x78,
-        0x9a, 0xbc, 0xde, 0xf0, 0x00, 0x00, 0x00, 0x00)
+t14_packed_addr = struct.pack('4B', 0xe0, 0x14, 0x0b, 0x40)
+t15_packed_addr = struct.pack(
+    '16B',
+    0xde, 0xad, 0xbe, 0xef, 0x12, 0x34, 0x56, 0x78,
+    0x9a, 0xbc, 0xde, 0xf0, 0x00, 0x00, 0x00, 0x00)
 
 
 class TestRadix(unittest.TestCase):
@@ -359,33 +347,6 @@ class TestRadix(unittest.TestCase):
                 node.data["j"] = j
         self.assertEquals(len(tree2.nodes()), num_nodes_in)
 
-    def test_21__cpickle(self):
-        if sys.version_info[0] >= 3:
-            return
-        tree = radix.Radix()
-        num_nodes_in = 0
-        for i in range(0, 128):
-            for j in range(0, 128):
-                k = ((i + j) % 8) + 24
-                addr = "1.%d.%d.0" % (i, j)
-                node = tree.add(addr, k)
-                node.data["i"] = i
-                node.data["j"] = j
-                num_nodes_in += 1
-        tree_pickled = cPickle.dumps(tree)
-        del tree
-        tree2 = cPickle.loads(tree_pickled)
-        for i in range(0, 128):
-            for j in range(0, 128):
-                k = ((i + j) % 8) + 24
-                addr = "1.%d.%d.0" % (i, j)
-                node = tree2.search_exact(addr, k)
-                self.assertNotEquals(node, None)
-                self.assertEquals(node.data["i"], i)
-                self.assertEquals(node.data["j"], j)
-                node.data["j"] = j
-        self.assertEquals(len(tree2.nodes()), num_nodes_in)
-
     def test_22_search_best(self):
         tree = radix.Radix()
         tree.add('10.0.0.0/8')
@@ -534,6 +495,7 @@ class TestRadix(unittest.TestCase):
 
 def main():
     unittest.main()
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Very first and likely incomplete and imperfect attempt to fix #59:

 - Add GitHub Action for Python package from GitHub template
 - Test Python >= 3.6 to cover RHEL 8 (including clones and forks such as Rocky Linux, Oracle Linux, AlmaLinux)
   - To explain the matrix decision:
     - Ubuntu 20.04 supports Python 3.6
     - Ubuntu >= 22.04 supports Python >= 3.7
 - Drop Python 2 support to allow `flake8` passing
 - For now, treat all `flake8` errors as warnings using `--exit-zero`
 - Add missing empty line to make `flake8` more happy

Obviously, tests for Python >= 3.12 fail until #44 etc. are merged.

I also don't know if you are fine with removal of Python 2 support, just treat this pull request as a starting point. I'm neither an expert in GitHub Actions nor in Python modules/packages, but as the RPM package maintainer of py-radix in Fedora and EPEL, I finally would like to see the downstream patches upstream and as you asked for contributions at https://github.com/mjschultz/py-radix/pull/58#issuecomment-2444718614, I'm simply beginning hereby. If you disagree with some of my decisions or would like to see changes, just let me know.