### PR TITLE
Fix E226, F841, W504, ignore C901, E741, W503 (spotted by flake8)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -52,7 +52,9 @@ jobs:
       run: |
         # Stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # For now, treat all errors as warnings using --exit-zero
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        # For now, ignore the single occurrence of E741 in _prefix_match(),
+        # ignore W503 in favor of PEP 8 suggesting Knuth's style, accept the
+        # max. complexity of 23 for RadixTree.add() - and just fail otherwise
+        flake8 . --count --ignore=E741,W503 --max-complexity=23 --max-line-length=127 --statistics
     - name: Test with pytest
       run: pytest

--- a/radix/__init__.py
+++ b/radix/__init__.py
@@ -1,6 +1,6 @@
 try:
     from ._radix import Radix as _Radix
-except Exception as e:
+except Exception:
     from .radix import Radix as _Radix
 
 __version__ = '0.10.0'

--- a/radix/radix.py
+++ b/radix/radix.py
@@ -122,8 +122,8 @@ class RadixTree(object):
         node = self.head
         # find the best place for the node
         while node.bitlen < bitlen or node._prefix.addr is None:
-            if (node.bitlen < self.maxbits and
-                    self._addr_test(addr, node.bitlen)):
+            if (node.bitlen < self.maxbits
+                    and self._addr_test(addr, node.bitlen)):
                 if node.right is None:
                     break
                 node = node.right
@@ -165,8 +165,8 @@ class RadixTree(object):
         # fix it up
         if node.bitlen == differ_bit:
             new_node.parent = node
-            if (node.bitlen < self.maxbits and
-                    self._addr_test(addr, node.bitlen)):
+            if (node.bitlen < self.maxbits
+                    and self._addr_test(addr, node.bitlen)):
                 node.right = new_node
             else:
                 node.left = new_node
@@ -272,8 +272,8 @@ class RadixTree(object):
         if len(stack) <= 0:
             return None
         for node in stack[::-1]:
-            if (self._prefix_match(node._prefix, prefix, node.bitlen) and
-                    node.bitlen <= bitlen):
+            if (self._prefix_match(node._prefix, prefix, node.bitlen)
+                    and node.bitlen <= bitlen):
                 return node
         return None
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -44,7 +44,7 @@ class TestRadix(unittest.TestCase):
         # it takes a number of tries to cause a problem, so this is more of a
         # smoke test
         curr_refs = sys.getrefcount(None)
-        for __ in range(curr_refs+1):
+        for __ in range(curr_refs + 1):
             self.assertEqual(type(None), type(node.parent))
 
     def test_00__create_destroy(self):


### PR DESCRIPTION
Try to get rid of the rest of the messages `flake8` raises:

```
./radix/__init__.py:3:1: F841 local variable 'e' is assigned to but never used
./radix/radix.py:50:5: C901 'RadixPrefix._from_network' is too complex (11)
./radix/radix.py:113:5: C901 'RadixTree.add' is too complex (23)
./radix/radix.py:206:5: C901 'RadixTree.remove' is too complex (11)
./radix/radix.py:357:9: E741 ambiguous variable name 'l'
./radix/radix.py:125:44: W504 line break after binary operator
./radix/radix.py:168:44: W504 line break after binary operator
./radix/radix.py:275:71: W504 line break after binary operator
./tests/test_regression.py:47:34: E226 missing whitespace around arithmetic operator
```

Note that W503 and W504 conflict each other, I read some preference in [PEP 8](https://peps.python.org/pep-0008/#should-a-line-break-before-or-after-a-binary-operator) for W504 (line break after binary operator) over W503 (line break occurred before a binary operator); let me know if you prefer this part reversed.

As `--exit-zero` is removed, `flake8` might fail hard now, but this hopefully avoids new warnings, errors etc.