### PR TITLE
Skip test that is very slow on Python 3.12 and newer

### DIFF
--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -37,6 +37,10 @@ class TestRadix(unittest.TestCase):
         'PyPy' == platform.python_implementation(),
         'PyPy has no refcounts'
     )
+    @unittest.skipIf(
+        sys.version_info >= (3, 12),
+        'None is immortal with a very large refcount in 3.12 and newer'
+    )
     def test_000_check_incref(self):
         tree = radix.Radix()
         node = tree.add('10.0.1.0/24')


### PR DESCRIPTION
Fixes #72.

I don't know why this test was added originally, maybe I just need to put a reasonable upper bound on the for loop. Definitely not 2^32-1:

```bash
goldbaum at Nathans-MBP in ~/Documents/py-radix on skip-slow-test
± python -c "import sys; print(sys.getrefcount(None))"
4294967295

goldbaum at Nathans-MBP in ~/Documents/py-radix on skip-slow-test
± python -VV
Python 3.13.7 (main, Aug 20 2025, 08:26:27) [Clang 17.0.0 (clang-1700.0.13.5)]
```